### PR TITLE
Remove coluna de comunicação da tabela de planos

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -76,13 +76,12 @@
                   <th scope="col">DIAS EM ATRASO</th>
                   <th scope="col">SALDO</th>
                   <th scope="col">DT SITUAÇÃO</th>
-                  <th scope="col">COMUNICAÇÃO</th>
                   <th scope="col">AÇÕES</th>
                 </tr>
               </thead>
               <tbody>
                 <tr class="table__row table__row--empty">
-                  <td class="table__cell" colspan="9">nada a exibir por aqui.</td>
+                  <td class="table__cell" colspan="8">nada a exibir por aqui.</td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
- remove a coluna de comunicação do cabeçalho da tabela de planos
- ajusta o colspan da linha vazia para refletir o novo número de colunas

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68da807a623c8323b0725dac02a8a280