### PR TITLE
Initialize PostgreSQL connection infrastructure

### DIFF
--- a/infra/db.py
+++ b/infra/db.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Optional
+
+from psycopg import AsyncConnection
+from psycopg_pool import AsyncConnectionPool
+
+from shared.config import DatabaseSettings, get_database_settings
+
+_pool: Optional[AsyncConnectionPool] = None
+_pool_lock = asyncio.Lock()
+
+
+async def init_pool(settings: Optional[DatabaseSettings] = None) -> AsyncConnectionPool:
+    """Initialise (or return) the global connection pool."""
+    global _pool
+    if _pool is not None:
+        return _pool
+
+    async with _pool_lock:
+        if _pool is not None:
+            return _pool
+
+        settings = settings or get_database_settings()
+        _pool = AsyncConnectionPool(
+            conninfo=settings.dsn,
+            min_size=settings.pool_min_size,
+            max_size=settings.pool_max_size,
+            timeout=settings.timeout,
+        )
+        return _pool
+
+
+async def close_pool() -> None:
+    """Close the existing pool, if any."""
+    global _pool
+    if _pool is None:
+        return
+
+    async with _pool_lock:
+        if _pool is not None:
+            await _pool.close()
+            _pool = None
+
+
+@asynccontextmanager
+async def get_connection() -> AsyncIterator[AsyncConnection]:
+    """Yield a database connection from the pool."""
+    pool = await init_pool()
+    async with pool.connection() as connection:
+        yield connection
+
+
+async def ping() -> None:
+    """Verify that the database connection is reachable."""
+    async with get_connection() as connection:
+        await connection.execute("SELECT 1")
+
+
+__all__ = ["init_pool", "close_pool", "get_connection", "ping"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+psycopg[binary]>=3.2,<4.0
+psycopg-pool>=3.2,<4.0

--- a/shared/config.py
+++ b/shared/config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+from urllib.parse import quote_plus
+
+
+@dataclass(slots=True)
+class DatabaseSettings:
+    """Configuration parameters required to connect to PostgreSQL."""
+
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+    application_name: str
+    ssl_mode: Optional[str] = None
+    pool_min_size: int = 1
+    pool_max_size: int = 10
+    timeout: float = 30.0
+
+    @property
+    def dsn(self) -> str:
+        """Return a ready-to-use DSN for psycopg or SQLAlchemy engines."""
+        user = quote_plus(self.user)
+        password = quote_plus(self.password)
+        application_name = quote_plus(self.application_name)
+        base = (
+            f"postgresql://{user}:{password}@{self.host}:{self.port}/"
+            f"{self.database}"
+        )
+        params = [f"application_name={application_name}"]
+        if self.ssl_mode:
+            params.insert(0, f"sslmode={quote_plus(self.ssl_mode)}")
+        return f"{base}?{'&'.join(params)}"
+
+
+@lru_cache(maxsize=1)
+def get_database_settings() -> DatabaseSettings:
+    """Load settings from environment variables with sane defaults."""
+
+    return DatabaseSettings(
+        host=os.getenv("DB_HOST", "localhost"),
+        port=int(os.getenv("DB_PORT", "5432")),
+        user=os.getenv("DB_USER", "postgres"),
+        password=os.getenv("DB_PASSWORD", "postgres"),
+        database=os.getenv("DB_NAME", "sirep_db"),
+        application_name=os.getenv("DB_APP_NAME", "sirep2"),
+        ssl_mode=os.getenv("DB_SSL_MODE") or None,
+        pool_min_size=int(os.getenv("DB_POOL_MIN", "1")),
+        pool_max_size=int(os.getenv("DB_POOL_MAX", "10")),
+        timeout=float(os.getenv("DB_POOL_TIMEOUT", "30")),
+    )
+
+
+__all__ = ["DatabaseSettings", "get_database_settings"]


### PR DESCRIPTION
## Summary
- add configurable PostgreSQL settings helper with DSN generation
- provide an async psycopg connection pool with lifecycle helpers
- declare psycopg dependencies for the new database layer

## Testing
- python -m compileall shared/config.py infra/db.py

------
https://chatgpt.com/codex/tasks/task_e_68da877b6798832398c213ef84f77495