### PR TITLE
Restore compatibility for sirep.app import path

### DIFF
--- a/sirep/app/__init__.py
+++ b/sirep/app/__init__.py
@@ -1,0 +1,11 @@
+"""Compatibility package exposing the FastAPI application entrypoint.
+
+This module re-exports the lazily created FastAPI application used by
+``uvicorn``.  Historically the project exposed the app under
+``sirep.app.api``; keeping this import path available avoids breaking
+existing commands or deployment scripts.
+"""
+
+from sirep.api import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/sirep/app/api.py
+++ b/sirep/app/api.py
@@ -1,0 +1,9 @@
+"""Expose the FastAPI application instance under ``sirep.app.api``.
+
+Uvicorn commands in deployment scripts still reference this module, so it
+simply forwards the actual application object from :mod:`sirep.api`.
+"""
+
+from sirep.api import app, create_app
+
+__all__ = ["app", "create_app"]


### PR DESCRIPTION
## Summary
- add a compatibility package under `sirep.app` that re-exports the FastAPI application
- keep the historical `sirep.app.api` import path working for existing uvicorn commands

## Testing
- not run (FastAPI is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68da979be0dc83238b86e7fb791f2ce6