### PR TITLE
Use login password when starting pipeline

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -252,7 +252,9 @@ input:focus {
 .login-card__header {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+  align-items: center;
+  text-align: center;
 }
 
 .login-card__title {
@@ -260,12 +262,30 @@ input:focus {
   font-size: 24px;
   font-weight: 600;
   color: var(--primary);
+  text-align: center;
 }
 
 .login-card__subtitle {
   margin: 0;
   color: var(--muted);
   line-height: 1.4;
+  text-align: center;
+}
+
+.login-card__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(11, 95, 168, 0.12), rgba(73, 195, 182, 0.12));
+  color: var(--primary);
+}
+
+.login-card__icon svg {
+  width: 24px;
+  height: 24px;
 }
 
 .login-form {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -114,13 +114,21 @@ document.addEventListener('DOMContentLoaded', () => {
     setStatus('Iniciando...');
 
     try {
+      const payload = {};
+      if (window.Auth?.getPassword) {
+        const senha = Auth.getPassword();
+        if (senha) {
+          payload.senha = senha;
+        }
+      }
+
       const response = await fetch(`${PIPELINE_ENDPOINT}/start`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Accept': 'application/json',
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify(payload),
       });
 
       if (!response.ok) {

--- a/ui/js/login.js
+++ b/ui/js/login.js
@@ -4,6 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
+  if (window.feather) {
+    window.feather.replace();
+  }
+
   if (Auth.isAuthenticated()) {
     window.location.replace('index.html');
     return;
@@ -69,7 +73,12 @@ document.addEventListener('DOMContentLoaded', () => {
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
       .join(' ');
 
-    Auth.login({ username, remember: rememberInput.checked, name: displayName });
+    Auth.login({
+      username,
+      remember: rememberInput.checked,
+      name: displayName,
+      password: credentials.password,
+    });
     form.reset();
     window.location.replace('index.html');
   });

--- a/ui/login.html
+++ b/ui/login.html
@@ -10,6 +10,9 @@
     <main class="login" role="main">
       <section class="login-card" aria-labelledby="loginTitle">
         <header class="login-card__header">
+          <div class="login-card__icon" aria-hidden="true">
+            <i data-feather="lock"></i>
+          </div>
           <h1 id="loginTitle" class="login-card__title">SIREP 2.0</h1>
           <p class="login-card__subtitle">
             Acesse com a mesma senha do Rede Caixa.
@@ -60,6 +63,7 @@
       <p>CAIXA™ 2025</p>
     </footer>
 
+    <script src="https://unpkg.com/feather-icons"></script>
     <script src="js/auth.js"></script>
     <script src="js/login.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- center the login header and add a lock icon using the existing Feather icons
- store the login password in the front-end session and include it when starting the pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dab4224d088323936be0e2af8b7b35