### PR TITLE
Integrate SIREP persistence pipeline

### DIFF
--- a/infra/repositories.py
+++ b/infra/repositories.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
-from datetime import date, timedelta
-from typing import Any, Optional
+from datetime import date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any, Iterable, Optional
 
-from psycopg import Connection, sql
+from psycopg import Connection
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 
 from domain.enums import Step
 
+
+logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class PlanDTO:
@@ -25,6 +29,7 @@ class PlansRepository:
 
     def __init__(self, conn: Connection) -> None:
         self._conn = conn
+        self._situacao_parcela_atraso_id: Optional[str] = None
 
     def get_by_numero(self, numero_plano: str) -> Optional[PlanDTO]:
         """Busca um plano pelo número normalizado."""
@@ -55,6 +60,8 @@ class PlansRepository:
         """Insere ou atualiza o plano consolidando empregador, catálogos e atrasos."""
 
         campos = dict(campos)
+        parcelas_brutas = list(campos.pop("parcelas_atraso", []) or [])
+
         empregador_id = self._resolver_empregador(campos)
         situacao_id, situacao_codigo = self._resolver_situacao(campos.get("situacao_atual"))
         tipo_id = self._resolver_tipo_plano(campos.get("tipo"))
@@ -66,130 +73,72 @@ class PlansRepository:
         )
 
         status = campos.get("status")
-        if status is not None:
-            status_valor = getattr(status, "value", str(status))
-        else:
-            status_valor = None
-
+        status_valor = getattr(status, "value", str(status)) if status is not None else None
         representacao = campos.get("representacao")
         dt_proposta = campos.get("dt_proposta")
-        saldo = campos.get("saldo")
+        saldo_total = self._to_decimal(campos.get("saldo"))
         dt_situacao_atual = campos.get("dt_situacao_atual")
 
-        payload = {
-            "empregador_id": empregador_id,
-            "tipo_plano_id": tipo_id,
-            "resolucao_id": resolucao_id,
-            "situacao_plano_id": situacao_id,
-            "dt_proposta": dt_proposta,
-            "saldo_total": saldo,
-            "atraso_desde": atraso_desde,
-            "representacao": representacao,
-            "status": status_valor,
-            "dt_situacao_atual": dt_situacao_atual,
-        }
-
-        columns = [
-            "tenant_id",
-            "numero_plano",
-            "empregador_id",
-            "tipo_plano_id",
-            "resolucao_id",
-            "situacao_plano_id",
-            "dt_proposta",
-            "saldo_total",
-            "atraso_desde",
-            "representacao",
-            "status",
-            "dt_situacao_atual",
-        ]
-
-        values = [
-            sql.SQL("app.current_tenant_id()"),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-            sql.Placeholder(),
-        ]
-
-        update_assignments = [
-            sql.SQL(
-                "empregador_id = COALESCE(EXCLUDED.empregador_id, app.plano.empregador_id)"
-            ),
-            sql.SQL(
-                "tipo_plano_id = COALESCE(EXCLUDED.tipo_plano_id, app.plano.tipo_plano_id)"
-            ),
-            sql.SQL(
-                "resolucao_id = COALESCE(EXCLUDED.resolucao_id, app.plano.resolucao_id)"
-            ),
-            sql.SQL(
-                "situacao_plano_id = COALESCE(EXCLUDED.situacao_plano_id, app.plano.situacao_plano_id)"
-            ),
-            sql.SQL(
-                "dt_proposta = COALESCE(EXCLUDED.dt_proposta, app.plano.dt_proposta)"
-            ),
-            sql.SQL(
-                "saldo_total = COALESCE(EXCLUDED.saldo_total, app.plano.saldo_total)"
-            ),
-            sql.SQL(
-                "atraso_desde = COALESCE(EXCLUDED.atraso_desde, app.plano.atraso_desde)"
-            ),
-            sql.SQL(
-                "representacao = COALESCE(EXCLUDED.representacao, app.plano.representacao)"
-            ),
-            sql.SQL("status = COALESCE(EXCLUDED.status, app.plano.status)"),
-            sql.SQL(
-                "dt_situacao_atual = COALESCE(EXCLUDED.dt_situacao_atual, app.plano.dt_situacao_atual)"
-            ),
-        ]
-
-        params = [
-            numero_plano,
-            payload["empregador_id"],
-            payload["tipo_plano_id"],
-            payload["resolucao_id"],
-            payload["situacao_plano_id"],
-            payload["dt_proposta"],
-            payload["saldo_total"],
-            payload["atraso_desde"],
-            payload["representacao"],
-            payload["status"],
-            payload["dt_situacao_atual"],
-        ]
-
-        insert_query = sql.SQL(
-            """
-            INSERT INTO app.plano ({columns})
-                 VALUES ({values})
-            ON CONFLICT (numero_plano)
-              DO UPDATE SET {updates}
-            RETURNING id
-            """
-        ).format(
-            columns=sql.SQL(", ").join(map(sql.Identifier, columns)),
-            values=sql.SQL(", ").join(values),
-            updates=sql.SQL(", ").join(update_assignments),
-        )
-
         with self._conn.cursor(row_factory=dict_row) as cur:
-            cur.execute(insert_query, params)
+            cur.execute(
+                """
+                INSERT INTO app.plano (
+                    tenant_id, numero_plano, empregador_id,
+                    tipo_plano_id, resolucao_id, situacao_plano_id,
+                    dt_proposta, saldo_total, atraso_desde,
+                    representacao, status, dt_situacao_atual
+                )
+                VALUES (
+                    app.current_tenant_id(), %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s,
+                    %s, %s, %s
+                )
+                ON CONFLICT (numero_plano)
+                DO UPDATE SET
+                    empregador_id     = EXCLUDED.empregador_id,
+                    tipo_plano_id     = EXCLUDED.tipo_plano_id,
+                    resolucao_id      = EXCLUDED.resolucao_id,
+                    situacao_plano_id = EXCLUDED.situacao_plano_id,
+                    dt_proposta       = EXCLUDED.dt_proposta,
+                    saldo_total       = EXCLUDED.saldo_total,
+                    atraso_desde      = COALESCE(EXCLUDED.atraso_desde, app.plano.atraso_desde),
+                    representacao     = EXCLUDED.representacao,
+                    status            = EXCLUDED.status,
+                    dt_situacao_atual = EXCLUDED.dt_situacao_atual
+                RETURNING id
+                """,
+                (
+                    numero_plano,
+                    empregador_id,
+                    tipo_id,
+                    resolucao_id,
+                    situacao_id,
+                    dt_proposta,
+                    saldo_total,
+                    atraso_desde,
+                    representacao,
+                    status_valor,
+                    dt_situacao_atual,
+                ),
+            )
             resultado = cur.fetchone()
 
         if not resultado:
             raise RuntimeError("Falha ao inserir/atualizar plano")
 
-        plan_id = str(resultado["id"])
+        plano_id = str(resultado["id"])
+
+        parcelas_preparadas = self._preparar_parcelas(parcelas_brutas)
+        if parcelas_preparadas:
+            alterado = self._persistir_parcelas(plano_id, parcelas_preparadas)
+            if alterado:
+                self._recalcular_atraso(plano_id)
+
         existente = self.get_by_numero(numero_plano)
         if existente is not None:
             return existente
-        return PlanDTO(plan_id, numero_plano, situacao_codigo)
+        return PlanDTO(plano_id, numero_plano, situacao_codigo)
 
     # -- Helpers -----------------------------------------------------------------
 
@@ -198,8 +147,14 @@ class PlansRepository:
         if not numero:
             return campos.get("empregador_id")
 
-        codigo_tipo = self._inferir_tipo_inscricao(numero)
+        numero_normalizado = self._only_digits(numero) or str(numero).strip()
+        if not numero_normalizado:
+            return campos.get("empregador_id")
+
+        codigo_tipo = self._inferir_tipo_inscricao(numero_normalizado)
         razao_social = campos.get("razao_social") or None
+        email = (campos.get("email") or "").strip() or None
+        telefone = (campos.get("telefone") or "").strip() or None
 
         with self._conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
@@ -213,17 +168,21 @@ class PlansRepository:
             cur.execute(
                 """
                 INSERT INTO app.empregador (
-                    tenant_id, tipo_inscricao_id, numero_inscricao, razao_social
+                    tenant_id, tipo_inscricao_id, numero_inscricao, razao_social,
+                    email, telefone
                 )
                 VALUES (
-                    app.current_tenant_id(), %s, %s, %s
+                    app.current_tenant_id(), %s, %s, %s,
+                    %s, %s
                 )
                 ON CONFLICT (tenant_id, tipo_inscricao_id, numero_inscricao)
                 DO UPDATE SET
-                    razao_social = COALESCE(EXCLUDED.razao_social, app.empregador.razao_social)
+                    razao_social = COALESCE(EXCLUDED.razao_social, app.empregador.razao_social),
+                    email = COALESCE(EXCLUDED.email, app.empregador.email),
+                    telefone = COALESCE(EXCLUDED.telefone, app.empregador.telefone)
                 RETURNING id
                 """,
-                (tipo["id"], numero, razao_social),
+                (tipo["id"], numero_normalizado, razao_social, email, telefone),
             )
             row = cur.fetchone()
 
@@ -333,7 +292,9 @@ class PlansRepository:
         if dias < 0:
             return None
 
-        if isinstance(referencia, date):
+        if isinstance(referencia, datetime):
+            base = referencia.date()
+        elif isinstance(referencia, date):
             base = referencia
         else:
             base = date.today()
@@ -361,19 +322,213 @@ class PlansRepository:
         if not texto:
             return "EM_DIA"
 
-        if texto.startswith("P.") or texto.startswith("P "):
-            return "P_RESCISAO"
-        if texto.startswith("PRESC"):
-            return "P_RESCISAO"
-        if "SIT" in texto and "ESPECIAL" in texto:
-            return "SIT_ESPECIAL"
-        if "RESCINDIDO" in texto:
-            return "RESCINDIDO"
-        if "LIQ" in texto:
-            return "LIQUIDADO"
-        if "GRDE" in texto:
+        normalizado = texto.strip().upper()
+        if not normalizado:
+            return "EM_DIA"
+
+        if "GRDE" in normalizado:
             return "GRDE_EMITIDA"
+        if "SIT" in normalizado and "ESPECIAL" in normalizado:
+            return "SIT_ESPECIAL"
+        if "LIQ" in normalizado:
+            return "LIQUIDADO"
+        if normalizado.startswith("P.") or normalizado.startswith("P ") or normalizado.startswith("PRESC"):
+            return "P_RESCISAO"
+        if "P. RESCISAO" in normalizado:
+            return "P_RESCISAO"
+        if normalizado.startswith("RESC") or "RESCINDIDO" in normalizado:
+            return "RESCINDIDO"
         return "EM_DIA"
+
+    @staticmethod
+    def _only_digits(valor: Any) -> str:
+        texto = "".join(ch for ch in str(valor or "") if ch.isdigit())
+        return texto
+
+    @staticmethod
+    def _safe_int(valor: Any) -> Optional[int]:
+        if valor is None:
+            return None
+        texto = str(valor).strip()
+        if not texto:
+            return None
+        digits = PlansRepository._only_digits(texto)
+        candidato = digits or texto
+        try:
+            return int(candidato)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _parse_vencimento(valor: Any) -> Optional[date]:
+        if isinstance(valor, datetime):
+            return valor.date()
+        if isinstance(valor, date):
+            return valor
+        texto = str(valor or "").strip()
+        if not texto:
+            return None
+        for fmt in ("%Y-%m-%d", "%d/%m/%Y"):
+            try:
+                return datetime.strptime(texto, fmt).date()
+            except ValueError:
+                continue
+        return None
+
+    @staticmethod
+    def _to_decimal(valor: Any) -> Optional[Decimal]:
+        if valor is None:
+            return None
+        if isinstance(valor, Decimal):
+            return valor
+        if isinstance(valor, (int, float)):
+            return Decimal(str(valor))
+        texto = str(valor).strip()
+        if not texto:
+            return None
+        texto_normalizado = texto.replace(".", "").replace(",", ".")
+        try:
+            return Decimal(texto_normalizado)
+        except InvalidOperation:
+            return None
+
+    def _preparar_parcelas(
+        self, parcelas: Iterable[Any]
+    ) -> list[dict[str, Any]]:
+        registros: list[dict[str, Any]] = []
+        for bruto in parcelas:
+            if not isinstance(bruto, dict):
+                continue
+            numero = self._safe_int(bruto.get("parcela"))
+            if numero is None:
+                continue
+            vencimento = self._parse_vencimento(bruto.get("vencimento"))
+            if vencimento is None:
+                continue
+            valor = self._to_decimal(bruto.get("valor_num"))
+            if valor is None:
+                valor = self._to_decimal(bruto.get("valor"))
+            if valor is None:
+                continue
+            qtd_total = self._safe_int(
+                bruto.get("qtd_parcelas_total")
+                or bruto.get("qtd_total")
+                or bruto.get("total")
+            )
+            registros.append(
+                {
+                    "nr_parcela": numero,
+                    "vencimento": vencimento,
+                    "valor": valor,
+                    "qtd_total": qtd_total,
+                }
+            )
+        return registros
+
+    def _situacao_parcela_em_atraso(self) -> Optional[str]:
+        if self._situacao_parcela_atraso_id is not None:
+            return self._situacao_parcela_atraso_id
+
+        with self._conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT id FROM ref.situacao_parcela WHERE codigo = %s",
+                ("EM_ATRASO",),
+            )
+            row = cur.fetchone()
+
+        if row:
+            self._situacao_parcela_atraso_id = str(row["id"])
+        else:
+            logger.warning("Situação de parcela 'EM_ATRASO' não encontrada no catálogo")
+            self._situacao_parcela_atraso_id = None
+        return self._situacao_parcela_atraso_id
+
+    def _persistir_parcelas(
+        self, plano_id: str, parcelas: list[dict[str, Any]]
+    ) -> bool:
+        if not parcelas:
+            return False
+
+        situacao_id = self._situacao_parcela_em_atraso()
+        alterado = False
+
+        merge_sql = """
+            WITH sel AS (
+                SELECT id
+                  FROM app.parcela
+                 WHERE tenant_id = app.current_tenant_id()
+                   AND plano_id = %s
+                   AND nr_parcela = %s
+                   AND vencimento = %s
+                 LIMIT 1
+            ),
+            ins AS (
+                INSERT INTO app.parcela (
+                    tenant_id, plano_id, nr_parcela, vencimento, valor,
+                    situacao_parcela_id, pago_em, valor_pago, qtd_parcelas_total
+                )
+                SELECT
+                    app.current_tenant_id(), %s, %s, %s, %s,
+                    %s, %s, %s, %s
+                WHERE NOT EXISTS (SELECT 1 FROM sel)
+                RETURNING id, 'insert'::text AS acao
+            ),
+            upd AS (
+                UPDATE app.parcela p
+                   SET valor = %s,
+                       situacao_parcela_id = COALESCE(%s, p.situacao_parcela_id),
+                       pago_em = %s,
+                       valor_pago = %s,
+                       qtd_parcelas_total = COALESCE(%s, p.qtd_parcelas_total),
+                       updated_at = now(),
+                       updated_by = app.current_user_id()
+                 WHERE p.id = (SELECT id FROM sel)
+                RETURNING p.id, 'update'::text AS acao
+            )
+            SELECT * FROM ins
+            UNION ALL
+            SELECT * FROM upd
+            UNION ALL
+            SELECT id, 'noop'::text AS acao FROM sel
+        """
+
+        for registro in parcelas:
+            params = (
+                plano_id,
+                registro["nr_parcela"],
+                registro["vencimento"],
+                plano_id,
+                registro["nr_parcela"],
+                registro["vencimento"],
+                registro["valor"],
+                situacao_id,
+                None,
+                None,
+                registro.get("qtd_total"),
+                registro["valor"],
+                situacao_id,
+                None,
+                None,
+                registro.get("qtd_total"),
+            )
+
+            with self._conn.cursor(row_factory=dict_row) as cur:
+                cur.execute(merge_sql, params)
+                rows = cur.fetchall()
+
+            for row in rows:
+                acao = row.get("acao")
+                if acao in {"insert", "update"}:
+                    alterado = True
+
+        return alterado
+
+    def _recalcular_atraso(self, plano_id: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT app.recalc_plano_atraso(app.current_tenant_id(), %s)",
+                (plano_id,),
+            )
 
 
 class EventsRepository:
@@ -427,10 +582,16 @@ class OccurrenceRepository:
                 return
 
             mensagem = f"Ocorrência {situacao} para plano {numero_plano}"
+            documento = PlansRepository._only_digits(cnpj) or (cnpj or "").strip() or None
+            if isinstance(saldo, Decimal):
+                saldo_json: Optional[str | float] = str(saldo)
+            else:
+                saldo_json = saldo
             payload = {
-                "cnpj": cnpj,
-                "tipo": tipo,
-                "saldo": saldo,
+                "numero_plano": numero_plano,
+                "documento": documento,
+                "tipo_plano": tipo,
+                "saldo_total": saldo_json,
                 "dt_situacao_atual": dt_situacao_atual.isoformat(),
             }
 

--- a/services/base.py
+++ b/services/base.py
@@ -1,14 +1,22 @@
 from __future__ import annotations
 
+import logging
 import os
+import time
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Callable, Optional
 
 import psycopg
+from psycopg.errors import UniqueViolation
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
 
 from domain.enums import Step
 from infra.repositories import EventsRepository, PlansRepository
 from shared.config import get_database_settings
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
@@ -35,17 +43,115 @@ class StepJobContext:
     db: psycopg.Connection
     plans: PlansRepository
     events: EventsRepository
+    job_run_id: str
+    job_run_started_at: datetime
 
 
 StepJobCallback = Callable[[StepJobContext], StepJobOutcome]
 
 
-def _prepare_context(connection: psycopg.Connection) -> StepJobContext:
+def _prepare_context(
+    connection: psycopg.Connection,
+    *,
+    job_run_id: str,
+    job_run_started_at: datetime,
+) -> StepJobContext:
     """Inicializa o contexto com os repositórios necessários."""
 
     plans = PlansRepository(connection)
     events = EventsRepository(connection)
-    return StepJobContext(db=connection, plans=plans, events=events)
+    return StepJobContext(
+        db=connection,
+        plans=plans,
+        events=events,
+        job_run_id=job_run_id,
+        job_run_started_at=job_run_started_at,
+    )
+
+
+def _configure_transaction(
+    connection: psycopg.Connection,
+    *,
+    tenant: Optional[str],
+    usuario: Optional[str],
+) -> None:
+    """Configura o contexto de RLS e parâmetros locais da transação."""
+
+    with connection.cursor() as cur:
+        if tenant:
+            cur.execute("SELECT app.set_tenant(%s)", (tenant,))
+        if usuario:
+            cur.execute("SELECT app.set_user(%s)", (usuario,))
+        cur.execute("SET TIME ZONE 'America/Sao_Paulo'")
+        cur.execute("SET LOCAL statement_timeout = '30s'")
+
+
+def _insert_job_run(
+    connection: psycopg.Connection,
+    *,
+    tenant: Optional[str],
+    usuario: Optional[str],
+    job_name: str,
+    payload: Optional[dict[str, Any]] = None,
+) -> tuple[str, datetime]:
+    """Registra um novo job_run com status RUNNING e retorna os identificadores."""
+
+    _configure_transaction(connection, tenant=tenant, usuario=usuario)
+    with connection.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            INSERT INTO audit.job_run (tenant_id, job_name, status, payload)
+            VALUES (app.current_tenant_id(), %s, 'RUNNING', %s)
+            RETURNING id, started_at
+            """,
+            (job_name, Json(payload or {})),
+        )
+        row = cur.fetchone()
+
+    if not row:
+        raise RuntimeError("Falha ao registrar job_run")
+
+    connection.commit()
+    return (str(row["id"]), row["started_at"])
+
+
+def _finalize_job_run(
+    connection: psycopg.Connection,
+    *,
+    tenant: Optional[str],
+    usuario: Optional[str],
+    job_run_id: str,
+    started_at: datetime,
+    status: str,
+    error_message: Optional[str] = None,
+) -> None:
+    """Atualiza o job_run com o status final e mensagem opcional."""
+
+    _configure_transaction(connection, tenant=tenant, usuario=usuario)
+    mensagem = (error_message or "").strip() or None
+    if mensagem and len(mensagem) > 2000:
+        mensagem = mensagem[:2000]
+
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE audit.job_run
+               SET status = %s,
+                   finished_at = now(),
+                   error_msg = %s
+             WHERE id = %s
+               AND started_at = %s
+            """,
+            (status, mensagem, job_run_id, started_at),
+        )
+
+
+def _retry_backoff(attempt: int) -> None:
+    """Aguarda um pequeno intervalo exponencial antes de nova tentativa."""
+
+    delay = min(2.0, 0.2 * (2 ** max(attempt - 1, 0)))
+    logger.debug("Esperando %.2fs para nova tentativa após unique_violation", delay)
+    time.sleep(delay)
 
 
 def run_step_job(
@@ -55,6 +161,8 @@ def run_step_job(
     callback: StepJobCallback,
     tenant_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    job_payload: Optional[dict[str, Any]] = None,
+    max_retries: int = 3,
 ) -> ServiceResult:
     """Executa o callback dentro de uma transação configurada com RLS."""
 
@@ -69,18 +177,73 @@ def run_step_job(
             cur.execute(
                 "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED"
             )
-            if tenant:
-                cur.execute("SELECT app.set_tenant(%s)", (tenant,))
-            if usuario:
-                cur.execute("SELECT app.set_user(%s)", (usuario,))
 
-        context = _prepare_context(connection)
-        outcome = callback(context)
-        connection.commit()
-        return ServiceResult(step=step, outcome=outcome)
-    except Exception:
-        connection.rollback()
-        raise
+        job_run_id, started_at = _insert_job_run(
+            connection,
+            tenant=tenant,
+            usuario=usuario,
+            job_name=str(job_name),
+            payload=job_payload,
+        )
+
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                _configure_transaction(connection, tenant=tenant, usuario=usuario)
+                context = _prepare_context(
+                    connection, job_run_id=job_run_id, job_run_started_at=started_at
+                )
+                outcome = callback(context)
+                final_status = outcome.status.upper() if outcome.status else "SUCCESS"
+                if final_status not in {"SUCCESS", "ERROR"}:
+                    final_status = "ERROR" if final_status.startswith("FAIL") else "SUCCESS"
+                _finalize_job_run(
+                    connection,
+                    tenant=tenant,
+                    usuario=usuario,
+                    job_run_id=job_run_id,
+                    started_at=started_at,
+                    status=final_status,
+                    error_message=None,
+                )
+                connection.commit()
+                return ServiceResult(step=step, outcome=outcome)
+            except UniqueViolation as exc:
+                logger.warning(
+                    "Unique violation durante execução da etapa %s (tentativa %s/%s)",
+                    step,
+                    attempt,
+                    max_retries,
+                )
+                connection.rollback()
+                if attempt >= max_retries:
+                    _finalize_job_run(
+                        connection,
+                        tenant=tenant,
+                        usuario=usuario,
+                        job_run_id=job_run_id,
+                        started_at=started_at,
+                        status="ERROR",
+                        error_message=str(exc),
+                    )
+                    connection.commit()
+                    raise
+                _retry_backoff(attempt)
+                continue
+            except Exception as exc:
+                connection.rollback()
+                _finalize_job_run(
+                    connection,
+                    tenant=tenant,
+                    usuario=usuario,
+                    job_run_id=job_run_id,
+                    started_at=started_at,
+                    status="ERROR",
+                    error_message=str(exc),
+                )
+                connection.commit()
+                raise
     finally:
         connection.close()
 

--- a/services/gestao_base/persistence.py
+++ b/services/gestao_base/persistence.py
@@ -145,9 +145,7 @@ def persist_rows(
         representacao = _representacao_value(inscricao_original, inscricao_canonica)
         if representacao is not None:
             campos["representacao"] = representacao
-        campos["parcelas_atraso"] = parcelas_normalizadas or None
-        if parcelas_normalizadas:
-            campos["parcelas_atraso"] = parcelas_normalizadas
+        campos["parcelas_atraso"] = parcelas_normalizadas
 
         campos["dias_em_atraso"] = dias_calculado
 


### PR DESCRIPTION
## Summary
- configure the pipeline service runner to open tenant-scoped transactions, track audit.job_run lifecycle and retry on unique-violation conflicts
- rewrite the plan persistence layer to follow SIREP rules for employers, plans, and parcelas, including atraso recalculation and occurrence payloads
- forward normalized parcelas data from the Gestão da Base pipeline into the repository layer for idempotent merging

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dabde7792083239117167deb7e6cc8