### PR TITLE
Handle missing fields when parsing Portal PO payloads

### DIFF
--- a/services/gestao_base/portal.py
+++ b/services/gestao_base/portal.py
@@ -62,15 +62,25 @@ def parse_portal_po(json_text: str) -> list[dict]:
         data = json.loads(json_text)
         if not data or not data[0].get("result"):
             return []
-        out: list[dict] = []
 
+        out: list[dict] = []
         for item in data[0].get("response", []):
+            if not isinstance(item, dict):
+                continue
+
             plano = norm_plano(item.get("cadastro_plano", ""))
-            cnpj = str(item.get("cadastro_inscricao", "")).strip()
-            tipo_raw = (item.get("tipo_descricao", item.get("cnpj", ""))).strip()
-            tipo = html.unescape(tipo_raw)
-            if plano:
-                out.append({"Plano": plano, "CNPJ": cnpj, "Tipo": tipo})
+            if not plano:
+                continue
+
+            cnpj_raw = item.get("cadastro_inscricao")
+            cnpj = str(cnpj_raw or "").strip()
+
+            tipo_source = item.get("tipo_descricao")
+            if not tipo_source:
+                tipo_source = item.get("cnpj")
+            tipo = html.unescape(str(tipo_source or "").strip())
+
+            out.append({"Plano": plano, "CNPJ": cnpj, "Tipo": tipo})
         return out
     except JSONDecodeError as e:
         logger.warning(f"JSON inválido do Portal PO: {e}")

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1,0 +1,43 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.gestao_base.portal import parse_portal_po
+
+
+def test_parse_portal_po_handles_missing_fields_and_html_entities():
+    payload = [
+        {
+            "result": True,
+            "response": [
+                {
+                    "cadastro_plano": "123.456-7",
+                    "cadastro_inscricao": None,
+                    "tipo_descricao": None,
+                    "cnpj": "Especial &amp; Unit",
+                },
+                {
+                    "cadastro_plano": "",
+                    "cadastro_inscricao": "11.222.333/0001-44",
+                    "tipo_descricao": "   ",
+                },
+                "ignorado",
+            ],
+        }
+    ]
+
+    resultado = parse_portal_po(json.dumps(payload))
+
+    assert resultado == [
+        {"Plano": "1234567", "CNPJ": "", "Tipo": "Especial & Unit"}
+    ]
+
+
+def test_parse_portal_po_empty_response():
+    payload = [{"result": True, "response": []}]
+
+    assert parse_portal_po(json.dumps(payload)) == []


### PR DESCRIPTION
## Summary
- guard the Portal PO parser against malformed rows lacking tipo or inscricao values
- ensure we only emit sanitized plan entries and unescape HTML entities
- add regression tests for parse_portal_po covering missing fields and empty responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dac5165070832381a9eee78d7b5e85