### PR TITLE
Harden login authorization checks

### DIFF
--- a/shared/auth.py
+++ b/shared/auth.py
@@ -19,10 +19,32 @@ def _iter_login_values(row: Any) -> Iterable[Any]:
     return (row,)
 
 
+_FALSEY_STRINGS = {"", "0", "false", "f", "no", "não", "nao"}
+
+
+def _is_truthy(value: Any) -> bool:
+    """Return ``True`` when ``value`` should be considered an affirmative flag."""
+
+    if value is None:
+        return False
+
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, (int, float)):
+        return value != 0
+
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized not in _FALSEY_STRINGS
+
+    return True
+
+
 def is_authorized_login(row: Any) -> bool:
     """Return ``True`` when the login result indicates a valid user."""
 
-    return any(value not in (None, "", False) for value in _iter_login_values(row))
+    return any(_is_truthy(value) for value in _iter_login_values(row))
 
 
 __all__ = ["is_authorized_login"]

--- a/tests/test_db_session.py
+++ b/tests/test_db_session.py
@@ -49,6 +49,21 @@ async def test_bind_session_rejects_unknown_matricula():
 
 
 @pytest.mark.anyio
+async def test_bind_session_rejects_falsey_string_response():
+    connection = AsyncMock()
+    login_cursor = AsyncMock()
+    login_cursor.fetchone = AsyncMock(return_value=("f",))
+    connection.execute = AsyncMock(side_effect=[login_cursor])
+
+    with pytest.raises(PermissionError) as excinfo:
+        await bind_session(connection, "abc123")
+
+    assert str(excinfo.value) == "Usuário não autorizado."
+    assert connection.execute.await_count == 1
+    login_cursor.fetchone.assert_awaited()
+
+
+@pytest.mark.anyio
 async def test_bind_session_requires_matricula():
     connection = AsyncMock()
 


### PR DESCRIPTION
## Summary
- tighten login authorisation helper to recognise common falsey database values
- add regression test ensuring sessions reject string responses returned as false by the database

## Testing
- pytest tests/test_db_session.py

------
https://chatgpt.com/codex/tasks/task_e_68db06b7cb8c8323bccda017f5f870f7