### PR TITLE
Handle optional certifi dependency and tidy service imports

### DIFF
--- a/services/gestao_base/portal.py
+++ b/services/gestao_base/portal.py
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 
 
 def portal_po_provider() -> List[dict]:  # pragma: no cover - integração real
-    import certifi_win32
+    try:  # pragma: no cover - dependência opcional em Windows
+        import certifi_win32  # noqa: F401
+    except ModuleNotFoundError:  # pragma: no cover - ambiente Linux/macOS
+        logger.debug("certifi_win32 não disponível; prosseguindo sem patch de certificados")
     import requests
     from requests_negotiate_sspi import HttpNegotiateAuth
 

--- a/services/gestao_base/service.py
+++ b/services/gestao_base/service.py
@@ -17,7 +17,7 @@ from services.base import (
 )
 
 from .collectors import DryRunCollector, GestaoBaseCollector, TerminalCollector
-from .models import GestaoBaseData, ProgressCallback
+from .models import ProgressCallback
 from .persistence import format_summary, persist_rows
 from .portal import portal_po_provider
 


### PR DESCRIPTION
## Summary
- make the Portal PO collector robust when certifi_win32 is unavailable by logging and continuing
- remove an unused GestaoBaseData import from the Gestão da Base service module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db0ad1118c8323a58eb0c327887148