### PR TITLE
Prevent psycopg async pool deprecation warning

### DIFF
--- a/infra/db.py
+++ b/infra/db.py
@@ -25,13 +25,16 @@ async def init_pool(settings: Optional[DatabaseSettings] = None) -> AsyncConnect
             return _pool
 
         settings = settings or get_database_settings()
-        _pool = AsyncConnectionPool(
+        pool = AsyncConnectionPool(
             conninfo=settings.dsn,
             min_size=settings.pool_min_size,
             max_size=settings.pool_max_size,
             timeout=settings.timeout,
+            open=False,
         )
-        return _pool
+        await pool.open()
+        _pool = pool
+        return pool
 
 
 async def close_pool() -> None:


### PR DESCRIPTION
## Summary
- create the async connection pool without opening it immediately
- explicitly open the pool after construction to avoid the constructor warning

## Testing
- python -m compileall infra/db.py

------
https://chatgpt.com/codex/tasks/task_e_68db1b7f34f48323ba5205118ed82e66