### PR TITLE
Handle None vencimento aliases in parcel normalization

### DIFF
--- a/services/gestao_base/parcelas.py
+++ b/services/gestao_base/parcelas.py
@@ -23,8 +23,12 @@ def _first_non_empty(mapping: dict[str, Any], keys: Iterable[str]) -> Optional[s
 
 def _first_present(mapping: dict[str, Any], keys: Iterable[str]) -> Any:
     for key in keys:
-        if key in mapping:
-            return mapping[key]
+        if key not in mapping:
+            continue
+        value = mapping[key]
+        if value is None:
+            continue
+        return value
     return None
 
 

--- a/tests/services/test_gestao_base_parcelas.py
+++ b/tests/services/test_gestao_base_parcelas.py
@@ -63,3 +63,20 @@ def test_normalize_parcelas_returns_empty_when_no_data():
     assert normalizados == []
     assert dias_total is None
 
+
+def test_normalize_parcelas_ignores_none_vencimento():
+    referencia = date(2024, 5, 10)
+    parcelas = [
+        {
+            "parcela": "001",
+            "valor": "100,00",
+            "vencimento": None,
+            "data_vencimento": "03/05/2024",
+        }
+    ]
+
+    normalizados, dias_total = normalize_parcelas_atraso(parcelas, referencia=referencia)
+
+    assert normalizados[0]["vencimento"] == "2024-05-03"
+    assert dias_total == 7
+


### PR DESCRIPTION
## Summary
- skip None values when retrieving vencimento aliases so fallback keys are considered
- add a regression test covering parcels where the primary vencimento field is None

## Testing
- pytest tests/services/test_gestao_base_parcelas.py

------
https://chatgpt.com/codex/tasks/task_e_68db1bd197ac8323ad88a61b9757a4d2