### PR TITLE
Adjust login subtitle color

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -6,6 +6,7 @@
   --card-bg: #ffffff;
   --text: #1f2937;
   --muted: #6b7280;
+  --muted-light: #9ca3af;
   --border: #e5e7eb;
   --shadow: 0 8px 20px rgba(0, 0, 0, 0.06);
   --primary: #0b5fa8;
@@ -267,7 +268,7 @@ input:focus {
 
 .login-card__subtitle {
   margin: 0;
-  color: var(--muted);
+  color: var(--muted-light);
   line-height: 1.4;
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- add a lighter muted color token for login subtitles
- apply the lighter tone to the login card subtitle for a more discreet appearance

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68db1e087c4c8323a9ad13da40644791