### PR TITLE
Include UI assets in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ include = [
     "services",
     "shared",
     "sirep",
+    "ui",
 ]
 exclude = ["tests", "tests.*", "scripts", "scripts.*"]
 
 [tool.setuptools.package-data]
-"" = ["ui/**"]
+ui = ["**/*"]

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,6 @@
+"""Static assets for the SIREP web UI."""
+
+# This package exists so that setuptools can include the UI assets in the
+# built distribution. The files are referenced directly by the FastAPI
+# application when serving the single-page app.
+


### PR DESCRIPTION
## Summary
- add the `ui` package to setuptools discovery so the wheel includes the static assets
- add a package marker so the UI files are shipped alongside the FastAPI application

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db25409e488323b3aecf3f4788825a