### PR TITLE
Improve pipeline orchestrator status handling

### DIFF
--- a/tests/test_pipeline_context.py
+++ b/tests/test_pipeline_context.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from typing import Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -10,6 +11,7 @@ if str(ROOT) not in sys.path:
 
 from domain.enums import Step
 from services.base import ServiceResult, StepJobOutcome
+from domain.pipeline import PipelineStatus
 from services.gestao_base import service as gestao_module
 from services.orchestrator import PipelineOrchestrator
 
@@ -21,6 +23,14 @@ class _DummyService:
     def execute(self, matricula, senha):
         self.calls.append((matricula, senha))
         return ServiceResult(step=Step.ETAPA_1, outcome=StepJobOutcome())
+
+
+class _ConfiguredService:
+    def __init__(self, *, status: str = "SUCCESS", info_update: Optional[dict] = None):
+        self.outcome = StepJobOutcome(status=status, info_update=info_update)
+
+    def execute(self, *_args, **_kwargs):
+        return ServiceResult(step=Step.ETAPA_1, outcome=self.outcome)
 
 
 @pytest.fixture
@@ -50,6 +60,46 @@ async def test_orchestrator_forwards_matricula_and_senha(monkeypatch):
 
     assert dummy.calls == [("abc123", "secreta")]
     assert orchestrator.get_state().status.value == "succeeded"
+
+
+@pytest.mark.anyio
+async def test_orchestrator_reports_failure_status(monkeypatch):
+    service = _ConfiguredService(status="ERROR")
+    orchestrator = PipelineOrchestrator(service=service)
+
+    async def immediate_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", immediate_to_thread)
+
+    await orchestrator.start()
+    task = orchestrator._task
+    assert task is not None
+    await task
+
+    state = orchestrator.get_state()
+    assert state.status is PipelineStatus.FAILED
+    assert state.message == "Pipeline finalizada com erro."
+
+
+@pytest.mark.anyio
+async def test_orchestrator_uses_summary_on_success(monkeypatch):
+    service = _ConfiguredService(status="SKIPPED", info_update={"summary": "Sem novidades"})
+    orchestrator = PipelineOrchestrator(service=service)
+
+    async def immediate_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", immediate_to_thread)
+
+    await orchestrator.start()
+    task = orchestrator._task
+    assert task is not None
+    await task
+
+    state = orchestrator.get_state()
+    assert state.status is PipelineStatus.SUCCEEDED
+    assert state.message == "Sem novidades"
 
 
 def test_service_passes_matricula_to_run_step_job(monkeypatch):


### PR DESCRIPTION
## Summary
- treat error-like outcomes from the Gestão da Base pipeline as failures and provide clearer default messages
- exercise the orchestrator with new tests that cover success, failure, and summary handling scenarios

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68db25577ecc83239a62e1641215232b