### PR TITLE
Adjust progress bar colors for pipeline status

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -414,7 +414,12 @@ input:focus {
 .progress__bar {
   width: 35%;
   height: 100%;
-  background: linear-gradient(90deg, var(--brand-grad-start), var(--brand-grad-end));
+  background: linear-gradient(90deg, #ef7d00, #f7a600);
+  transition: background 0.3s ease-in-out;
+}
+
+.progress__bar--complete {
+  background: #00c853;
 }
 
 .section-title {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnStart = document.getElementById('btnStart');
   const btnPause = document.getElementById('btnPause');
   const btnContinue = document.getElementById('btnContinue');
+  const progressBar = document.querySelector('.progress__bar');
 
   const PIPELINE_ENDPOINT = '/api/pipeline';
   let pollHandle = null;
@@ -132,8 +133,21 @@ document.addEventListener('DOMContentLoaded', () => {
     }, 5000);
   };
 
+  const updateProgressBarAppearance = (status) => {
+    if (!progressBar) {
+      return;
+    }
+
+    progressBar.classList.remove('progress__bar--complete');
+
+    if (status === 'succeeded') {
+      progressBar.classList.add('progress__bar--complete');
+    }
+  };
+
   const applyState = (state) => {
     const message = state.message || defaultMessages[state.status] || defaultMessages.idle;
+    updateProgressBarAppearance(state.status);
     switch (state.status) {
       case 'running':
         toggleButtons({ start: false, pause: true, cont: false });


### PR DESCRIPTION
## Summary
- update the progress bar styling to use the required orange gradient while the pipeline is running
- switch the bar to a bright green theme when the pipeline completes successfully

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbb2044b188323857513a3c8b0a635