### PR TITLE
Fix virtualenv detection in cache cleaner

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for repository maintenance."""

--- a/scripts/clear_cache.py
+++ b/scripts/clear_cache.py
@@ -29,7 +29,7 @@ VENV_DIRECTORY_NAMES: tuple[str, ...] = (".venv",)
 
 def should_skip_directory(path: Path) -> bool:
     """Return True when the directory should be skipped during traversal."""
-    return any(part in VENV_DIRECTORY_NAMES for part in path.parts)
+    return path.name in VENV_DIRECTORY_NAMES
 
 
 def remove_directory(path: Path) -> None:

--- a/tests/scripts/test_clear_cache.py
+++ b/tests/scripts/test_clear_cache.py
@@ -1,0 +1,41 @@
+"""Tests for the cache clearing utility script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.clear_cache import iter_cache_directories
+
+
+def test_iter_cache_directories_in_repo_under_virtualenv(tmp_path: Path) -> None:
+    """Ensure caches are detected when the project root is inside a virtualenv."""
+    root = tmp_path / ".venv" / "project"
+    cache_dir = root / "__pycache__"
+    cache_dir.mkdir(parents=True)
+    bytecode_file = root / "module.pyc"
+    bytecode_file.write_text("")
+
+    targets = list(iter_cache_directories(root))
+
+    assert cache_dir in targets
+    assert bytecode_file in targets
+
+
+def test_iter_cache_directories_skip_nested_virtualenv(tmp_path: Path) -> None:
+    """Verify that nested virtual environment directories are not traversed."""
+    root = tmp_path / "project"
+    cache_dir = root / "__pycache__"
+    cache_dir.mkdir(parents=True)
+    nested_venv_cache = root / ".venv" / "__pycache__"
+    nested_venv_cache.mkdir(parents=True)
+
+    targets = list(iter_cache_directories(root))
+
+    assert cache_dir in targets
+    assert not any(target.is_relative_to(root / ".venv") for target in targets)


### PR DESCRIPTION
## Summary
- ensure the cache cleaner only skips directories named as virtual environments instead of all ancestors
- add a package initializer for the scripts module so it can be imported in tests
- cover the regression with new tests verifying behavior inside and below virtualenv directories

## Testing
- pytest tests/scripts/test_clear_cache.py


------
https://chatgpt.com/codex/tasks/task_e_68dbbdde065c8323974b21bce8e47b42