### PR TITLE
Adjust login card typography and spacing

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -244,23 +244,23 @@ input:focus {
   background: var(--card-bg);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
-  padding: 40px 36px;
+  padding: 32px 32px;
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 24px;
 }
 
 .login-card__header {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   align-items: center;
   text-align: center;
 }
 
 .login-card__title {
   margin: 0;
-  font-size: 24px;
+  font-size: 28px;
   font-weight: 600;
   color: var(--primary);
   text-align: center;
@@ -269,7 +269,8 @@ input:focus {
 .login-card__subtitle {
   margin: 0;
   color: var(--muted-light);
-  line-height: 1.6;
+  font-size: 13px;
+  line-height: 1.5;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- enlarge the login title while reducing subtitle size for better hierarchy
- tighten login card padding and spacing to avoid excessive height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc0aa76fc8323991bee56fa70bc1a