### PR TITLE
Reorganiza controles da Janela de Eventos (logs)

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -566,12 +566,6 @@ input:focus {
   cursor: pointer;
 }
 
-.logs-panel__export {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
 .logs-panel__label {
   font-size: 14px;
   color: var(--muted);
@@ -587,28 +581,43 @@ input:focus {
 .accordion__header {
   width: 100%;
   background: #f9fafb;
-  border: none;
   display: flex;
   align-items: center;
+  gap: 24px;
   justify-content: space-between;
   padding: 16px 20px;
+  flex-wrap: wrap;
+}
+
+.accordion__toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: none;
+  background: transparent;
+  padding: 0;
   font-size: 15px;
   font-weight: 600;
   color: var(--text);
-  cursor: default;
-}
-
-.accordion__header span {
   cursor: pointer;
 }
 
-.accordion__header i {
-  pointer-events: none;
+.accordion__toggle:focus {
+  outline-offset: 2px;
 }
 
-.accordion__header:hover,
-.accordion__header:focus {
-  background: #eef2f7;
+.accordion__toggle-label {
+  cursor: pointer;
+}
+
+.accordion__toggle-icon {
+  display: flex;
+  transition: transform 0.2s ease-in-out;
+}
+
+.accordion__toggle-icon .feather {
+  width: 16px;
+  height: 16px;
 }
 
 .accordion__panel {
@@ -622,6 +631,19 @@ input:focus {
 .accordion__panel.is-open,
 .accordion.is-open .accordion__panel {
   display: block;
+}
+
+.accordion.is-open .accordion__toggle-icon {
+  transform: rotate(90deg);
+}
+
+.logs-panel__controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin-left: auto;
 }
 
 .footer {
@@ -645,6 +667,18 @@ input:focus {
   .table-footer {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .accordion__header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .logs-panel__controls {
+    width: 100%;
+    justify-content: space-between;
+    gap: 16px;
   }
 
   .filters {

--- a/ui/index.html
+++ b/ui/index.html
@@ -101,19 +101,21 @@
           </div>
 
           <div class="accordion">
-            <button
-              class="accordion__header"
-              id="logsToggle"
-              type="button"
-              aria-expanded="false"
-              aria-controls="logsPanel"
-            >
-              <span>Janela de Eventos (logs)</span>
-              <i data-feather="chevron-down" aria-hidden="true"></i>
-            </button>
-            <div class="accordion__panel" id="logsPanel" role="region" aria-labelledby="logsToggle">
+            <div class="accordion__header">
+              <button
+                class="accordion__toggle"
+                id="logsToggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="logsPanel"
+              >
+                <span class="accordion__toggle-icon" aria-hidden="true">
+                  <i data-feather="chevron-right"></i>
+                </span>
+                <span class="accordion__toggle-label">Janela de Eventos (logs)</span>
+              </button>
               <div
-                class="logs-panel__export"
+                class="logs-panel__controls"
                 role="group"
                 aria-labelledby="logsExportLabel"
               >
@@ -172,6 +174,7 @@
                 </div>
               </div>
             </div>
+            <div class="accordion__panel" id="logsPanel" role="region" aria-labelledby="logsToggle"></div>
           </div>
         </div>
 

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -283,11 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   };
 
-  logsToggle.addEventListener('click', (event) => {
-    const textSpan = logsToggle.querySelector('span');
-    if (event.target !== textSpan) {
-      return;
-    }
+  logsToggle.addEventListener('click', () => {
     const isOpen = logsToggle.getAttribute('aria-expanded') === 'true';
     updateAccordionState(!isOpen);
   });


### PR DESCRIPTION
## Summary
- move os filtros de período e o botão de exportação para a barra da Janela de Eventos
- ajusta os estilos do acordeão e o comportamento do toggle para suportar o novo layout

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbc2d615f88323bcda7ddb30dc69a5