### PR TITLE
Record plan situation history with effective dates

### DIFF
--- a/tests/infra/test_plans_repository.py
+++ b/tests/infra/test_plans_repository.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+from psycopg.rows import dict_row
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from infra.repositories import PlanDTO, PlansRepository
+
+
+def _make_cursor(return_value: Any | None = None) -> tuple[MagicMock, MagicMock]:
+    cursor = MagicMock()
+    if return_value is not None:
+        cursor.fetchone.return_value = return_value
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+    return cursor, cursor_cm
+
+
+def test_registrar_historico_insere_quando_situacao_altera():
+    connection = MagicMock()
+    cursor, cursor_cm = _make_cursor()
+    connection.cursor.return_value = cursor_cm
+
+    repo = PlansRepository(connection)
+    repo._registrar_historico_situacao(
+        plano_id="plano-1",
+        situacao_id="sit-1",
+        situacao_codigo="RESCINDIDO",
+        situacao_anterior="EM_DIA",
+        dt_situacao_atual=date(2024, 5, 1),
+        observacao="Carga inicial",
+    )
+
+    connection.cursor.assert_called_once_with()
+    sql, params = cursor.execute.call_args[0]
+    assert "INSERT INTO app.plano_situacao_hist" in sql
+    assert params == ("plano-1", "sit-1", "2024-05-01", "Carga inicial")
+
+
+def test_registrar_historico_ignora_quando_situacao_repetida():
+    connection = MagicMock()
+    repo = PlansRepository(connection)
+
+    repo._registrar_historico_situacao(
+        plano_id="plano-1",
+        situacao_id="sit-1",
+        situacao_codigo="EM_DIA",
+        situacao_anterior="em_dia",
+        dt_situacao_atual=date(2024, 5, 1),
+    )
+
+    connection.cursor.assert_not_called()
+
+
+def test_registrar_historico_evita_duplicar_sem_situacao_anterior():
+    existente = {
+        "situacao_plano_id": "sit-1",
+        "mudou_em": datetime(2024, 5, 1, 0, 0, tzinfo=timezone.utc),
+    }
+    connection = MagicMock()
+    select_cursor, select_cm = _make_cursor(existente)
+    connection.cursor.return_value = select_cm
+
+    repo = PlansRepository(connection)
+    repo._registrar_historico_situacao(
+        plano_id="plano-1",
+        situacao_id="sit-1",
+        situacao_codigo="EM_DIA",
+        situacao_anterior=None,
+        dt_situacao_atual=date(2024, 5, 1),
+    )
+
+    connection.cursor.assert_called_once_with(row_factory=dict_row)
+    select_cursor.execute.assert_called_once()
+    select_cursor.fetchone.assert_called_once()
+
+
+def test_upsert_registra_historico_quando_informado():
+    connection = MagicMock()
+    insert_cursor, insert_cm = _make_cursor({"id": "uuid-1"})
+    connection.cursor.return_value = insert_cm
+
+    repo = PlansRepository(connection)
+    repo._resolver_empregador = MagicMock(return_value=None)
+    repo._resolver_situacao = MagicMock(return_value=("sit-1", "RESCINDIDO"))
+    repo._resolver_tipo_plano = MagicMock(return_value=None)
+    repo._resolver_resolucao = MagicMock(return_value=None)
+    repo._calcular_atraso_desde = MagicMock(return_value=None)
+    repo._to_decimal = MagicMock(return_value=None)
+    repo._registrar_historico_situacao = MagicMock()
+    repo.get_by_numero = MagicMock(
+        return_value=PlanDTO(id="uuid-1", numero_plano="123", situacao_atual="RESCINDIDO")
+    )
+
+    resultado = repo.upsert(
+        "123",
+        situacao_atual="Rescindido",
+        situacao_anterior="EM_DIA",
+        dt_situacao_atual=date(2024, 5, 1),
+        parcelas_atraso=[],
+    )
+
+    assert resultado.numero_plano == "123"
+    repo._registrar_historico_situacao.assert_called_once()
+    kwargs = repo._registrar_historico_situacao.call_args.kwargs
+    assert kwargs == {
+        "plano_id": "uuid-1",
+        "situacao_id": "sit-1",
+        "situacao_codigo": "RESCINDIDO",
+        "situacao_anterior": "EM_DIA",
+        "dt_situacao_atual": date(2024, 5, 1),
+    }
+


### PR DESCRIPTION
## Summary
- capture the official situation timestamp when persisting plans in the pipeline
- insert plan history rows with the provided effective date while avoiding duplicate entries
- add unit tests covering the new history logic in the plans repository

## Testing
- pytest tests/infra/test_plans_repository.py

------
https://chatgpt.com/codex/tasks/task_e_68dbcdab72248323af151bee062cbf8f