### PR TITLE
Add HTTP integration dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "psycopg[binary]>=3.2,<4.0",
     "psycopg-pool>=3.2,<4.0",
     "pydantic>=2.7,<3.0",
+    "python-certifi-win32>=1.6,<2.0; sys_platform == \"win32\"",
+    "requests>=2.31,<3.0",
+    "requests-negotiate-sspi>=0.5.2,<0.6",
     "uvicorn[standard]>=0.30,<0.32",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@ fastapi>=0.115,<0.116
 psycopg[binary]>=3.2,<4.0
 psycopg-pool>=3.2,<4.0
 pydantic>=2.7,<3.0
+python-certifi-win32>=1.6,<2.0; sys_platform == "win32"
+requests>=2.31,<3.0
+requests-negotiate-sspi>=0.5.2,<0.6
 uvicorn[standard]>=0.30,<0.32


### PR DESCRIPTION
## Summary
- include the HTTP client stack used by the Portal PO integration in requirements.txt
- mirror the same dependency additions in pyproject.toml so packaging remains consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd94317288323945c2c6c25f3aad9