### PR TITLE
Add occurrences table toggle for plans overview

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -441,10 +441,49 @@ input:focus {
   gap: 16px;
 }
 
+.section-title--tables {
+  justify-content: flex-start;
+  gap: 12px;
+}
+
 .section-title__heading {
   font-size: 16px;
   margin: 0;
   letter-spacing: 0.04em;
+}
+
+.section-switch {
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--muted);
+  padding: 8px 16px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.section-switch:hover,
+.section-switch:focus {
+  color: var(--primary);
+}
+
+.section-switch--active {
+  background: var(--primary);
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(11, 95, 168, 0.25);
+}
+
+.section-switch--active .section-switch__count {
+  color: inherit;
+}
+
+.section-switch__count {
+  margin-left: 8px;
+  font-size: 13px;
+  color: var(--primary);
 }
 
 .badge {
@@ -457,6 +496,16 @@ input:focus {
   border: 1px solid var(--border);
   border-radius: 10px;
   overflow: hidden;
+}
+
+.table-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.table-panel--hidden {
+  display: none;
 }
 
 .table table {

--- a/ui/index.html
+++ b/ui/index.html
@@ -61,42 +61,125 @@
             <div class="progress__bar"></div>
           </div>
 
-          <div class="section-title">
-            <h2 class="section-title__heading">TABELA DE PLANOS</h2>
-            <span class="badge" aria-live="polite">OCORRÊNCIAS (0)</span>
+          <div
+            class="section-title section-title--tables"
+            role="tablist"
+            aria-label="Listas de planos"
+          >
+            <button
+              class="section-switch section-switch--active"
+              id="plansTableTab"
+              type="button"
+              role="tab"
+              aria-selected="true"
+              aria-controls="plansTablePanel"
+              data-table-target="plans"
+              tabindex="0"
+            >
+              TABELA DE PLANOS
+            </button>
+            <button
+              class="section-switch"
+              id="occurrencesTableTab"
+              type="button"
+              role="tab"
+              aria-selected="false"
+              aria-controls="occurrencesTablePanel"
+              data-table-target="occurrences"
+              tabindex="-1"
+            >
+              OCORRÊNCIAS
+              <span class="section-switch__count" id="occurrencesCount">(0)</span>
+            </button>
           </div>
 
-          <div class="table" role="region" aria-labelledby="section-table">
-            <table aria-label="Tabela de planos">
-              <thead class="table__head">
-                <tr>
-                  <th scope="col">PLANO</th>
-                  <th scope="col">CNPJ</th>
-                  <th scope="col">RAZAO SOCIAL</th>
-                  <th scope="col">SITUAÇÃO</th>
-                  <th scope="col">DIAS EM ATRASO</th>
-                  <th scope="col">SALDO</th>
-                  <th scope="col">DT SITUAÇÃO</th>
-                  <th scope="col">AÇÕES</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr class="table__row table__row--empty">
-                  <td class="table__cell" colspan="8">nada a exibir por aqui.</td>
-                </tr>
-              </tbody>
-            </table>
+          <div
+            class="table-panel"
+            id="plansTablePanel"
+            role="tabpanel"
+            aria-labelledby="plansTableTab"
+            data-table-panel="plans"
+          >
+            <div class="table">
+              <table class="data-table" aria-label="Tabela de planos">
+                <thead class="table__head">
+                  <tr>
+                    <th scope="col">PLANO</th>
+                    <th scope="col">CNPJ</th>
+                    <th scope="col">RAZAO SOCIAL</th>
+                    <th scope="col">SITUAÇÃO</th>
+                    <th scope="col">DIAS EM ATRASO</th>
+                    <th scope="col">SALDO</th>
+                    <th scope="col">DT SITUAÇÃO</th>
+                    <th scope="col">AÇÕES</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="table__row table__row--empty">
+                    <td class="table__cell" colspan="8">nada a exibir por aqui.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="table-footer">
+              <div class="pager" role="navigation" aria-label="Paginação">
+                <button class="pager__btn" type="button" aria-disabled="true" disabled>
+                  <i data-feather="chevron-left" aria-hidden="true"></i>
+                </button>
+                <span class="pager__label">pág. 1 de 1</span>
+                <button class="pager__btn" type="button" aria-disabled="true" disabled>
+                  <i data-feather="chevron-right" aria-hidden="true"></i>
+                </button>
+              </div>
+            </div>
           </div>
 
-          <div class="table-footer">
-            <div class="pager" role="navigation" aria-label="Paginação">
-              <button class="pager__btn" type="button" aria-disabled="true" disabled>
-                <i data-feather="chevron-left" aria-hidden="true"></i>
-              </button>
-              <span class="pager__label">pág. 1 de 1</span>
-              <button class="pager__btn" type="button" aria-disabled="true" disabled>
-                <i data-feather="chevron-right" aria-hidden="true"></i>
-              </button>
+          <div
+            class="table-panel table-panel--hidden"
+            id="occurrencesTablePanel"
+            role="tabpanel"
+            aria-labelledby="occurrencesTableTab"
+            data-table-panel="occurrences"
+            hidden
+          >
+            <div class="table">
+              <table
+                class="data-table"
+                aria-label="Tabela de planos com ocorrências"
+              >
+                <thead class="table__head">
+                  <tr>
+                    <th scope="col">PLANO</th>
+                    <th scope="col">CNPJ</th>
+                    <th scope="col">RAZAO SOCIAL</th>
+                    <th scope="col">SITUAÇÃO</th>
+                    <th scope="col">DIAS EM ATRASO</th>
+                    <th scope="col">SALDO</th>
+                    <th scope="col">DT SITUAÇÃO</th>
+                    <th scope="col">AÇÕES</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr class="table__row table__row--empty">
+                    <td class="table__cell" colspan="8">
+                      nenhuma ocorrência por aqui.
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="table-footer">
+              <div class="pager" role="navigation" aria-label="Paginação de ocorrências">
+                <button class="pager__btn" type="button" aria-disabled="true" disabled>
+                  <i data-feather="chevron-left" aria-hidden="true"></i>
+                </button>
+                <span class="pager__label">pág. 1 de 1</span>
+                <button class="pager__btn" type="button" aria-disabled="true" disabled>
+                  <i data-feather="chevron-right" aria-hidden="true"></i>
+                </button>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add a tabbed switch next to the plans title to expose the new Ocorrências table
- create a dedicated Ocorrências table panel and styling while keeping pagination per table
- update the frontend script to support switching tables and formatting both datasets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbe0b161d083238a1983d83a08e960