### PR TITLE
Handle unauthorized login messages in shared auth helper

### DIFF
--- a/shared/auth.py
+++ b/shared/auth.py
@@ -20,6 +20,13 @@ def _iter_login_values(row: Any) -> Iterable[Any]:
 
 
 _FALSEY_STRINGS = {"", "0", "false", "f", "no", "não", "nao"}
+_NEGATIVE_MESSAGE_HINTS = {
+    "nao autorizado",
+    "não autorizado",
+    "unauthorized",
+    "access denied",
+    "acesso negado",
+}
 
 
 def _is_truthy(value: Any) -> bool:
@@ -36,6 +43,10 @@ def _is_truthy(value: Any) -> bool:
 
     if isinstance(value, str):
         normalized = value.strip().lower()
+        if not normalized:
+            return False
+        if any(hint in normalized for hint in _NEGATIVE_MESSAGE_HINTS):
+            return False
         return normalized not in _FALSEY_STRINGS
 
     return True

--- a/tests/test_shared_auth.py
+++ b/tests/test_shared_auth.py
@@ -1,0 +1,36 @@
+"""Tests for the authentication helpers module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from shared import auth
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"mensagem": "Usuário não autorizado."},
+        {"mensagem": "Acesso negado ao usuário"},
+        {"mensagem": "ACCESS DENIED"},
+    ],
+)
+def test_is_authorized_login_handles_failure_messages(payload):
+    """Failure messages without flags must not be considered authorised."""
+
+    assert auth.is_authorized_login(payload) is False
+
+
+def test_is_authorized_login_keeps_positive_values():
+    """Positive, non-empty values should still be treated as affirmative."""
+
+    assert auth.is_authorized_login({"resultado": "S"}) is True


### PR DESCRIPTION
## Summary
- treat textual denial messages returned by the login function as unauthorised instead of truthy values
- add regression tests that cover message-only payloads for `is_authorized_login`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbf07caeb083239116bf99df5022c7