### PR TITLE
Fix lookup cache to preserve status codes

### DIFF
--- a/infra/repositories.py
+++ b/infra/repositories.py
@@ -46,8 +46,7 @@ class LookupCache:
 
             cur.execute("SELECT codigo, id FROM ref.situacao_plano")
             situacoes = {
-                PlansRepository._normalizar_situacao(str(codigo)):
-                str(ident)
+                str(codigo).strip().upper(): str(ident)
                 for codigo, ident in cur.fetchall()
             }
 

--- a/tests/infra/test_plans_repository.py
+++ b/tests/infra/test_plans_repository.py
@@ -25,6 +25,30 @@ def _make_cursor(return_value: Any | None = None) -> tuple[MagicMock, MagicMock]
     return cursor, cursor_cm
 
 
+def test_lookup_cache_load_preserves_situacao_codes():
+    cursor = MagicMock()
+    cursor.fetchall.side_effect = [
+        [("tipo-a", "tipo-1")],
+        [("resol", "res-1")],
+        [("EM_DIA", "sit-1"), ("P_RESCISAO", "sit-2")],
+        [("CNPJ", "doc-1")],
+        [("BASE", "base-1")],
+    ]
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+
+    connection = MagicMock()
+    connection.cursor.return_value = cursor_cm
+
+    cache = LookupCache.load(connection)
+
+    assert cache.situacoes_plano == {
+        "EM_DIA": "sit-1",
+        "P_RESCISAO": "sit-2",
+    }
+
+
 def test_registrar_historico_insere_quando_situacao_altera():
     connection = MagicMock()
     cursor, cursor_cm = _make_cursor()


### PR DESCRIPTION
## Summary
- keep situation codes from the database when building the lookup cache to avoid collisions between canonical values
- add a regression test covering the cache loader to ensure distinct situacao entries are kept

## Testing
- pytest tests/infra/test_plans_repository.py::test_lookup_cache_load_preserves_situacao_codes

------
https://chatgpt.com/codex/tasks/task_e_68dbfe1557248323a47f052bef07a24b