### PR TITLE
Add audit job step logging and coverage

### DIFF
--- a/tests/services/test_run_step_job.py
+++ b/tests/services/test_run_step_job.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+from psycopg.errors import UniqueViolation
+
+from domain.enums import Step
+from services.base import ServiceResult, StepJobOutcome, run_step_job
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple | None]] = []
+
+    def execute(self, sql: str, params: tuple | None = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> None:  # pragma: no cover - compatibilidade com interface real
+        return None
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursors: list[_FakeCursor] = []
+        self.commits: int = 0
+        self.rollbacks: int = 0
+        self.closed: bool = False
+
+    def cursor(self, *args, **kwargs) -> _FakeCursor:  # pragma: no cover - simples encaminhamento
+        cursor = _FakeCursor()
+        self.cursors.append(cursor)
+        return cursor
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def _run_step_env(monkeypatch):
+    from services import base as base_module
+
+    connection = _FakeConnection()
+
+    monkeypatch.setattr(
+        base_module.psycopg,
+        "connect",
+        lambda dsn, autocommit=False: connection,
+    )
+
+    class _Settings(SimpleNamespace):
+        pass
+
+    monkeypatch.setattr(
+        base_module,
+        "get_database_settings",
+        lambda: _Settings(dsn="postgresql://fake"),
+    )
+    monkeypatch.setattr(
+        base_module,
+        "get_principal_settings",
+        lambda: _Settings(
+            tenant_id=None,
+            matricula="svc-user",
+            nome=None,
+            email=None,
+            perfil=None,
+        ),
+    )
+    monkeypatch.setattr(base_module, "bind_session_by_matricula", lambda *_: None)
+    monkeypatch.setattr(base_module, "_retry_backoff", lambda *_: None)
+
+    handle_ref: dict[str, SimpleNamespace] = {}
+
+    @contextmanager
+    def fake_job_run(conn, job_name, payload=None):
+        handle = SimpleNamespace(
+            tenant_id="tenant",
+            started_at=datetime(2024, 1, 1, 12, 0, 0),
+            id="job-id",
+            status=None,
+            error_message=None,
+        )
+        handle_ref["handle"] = handle
+        yield handle
+
+    monkeypatch.setattr(base_module, "job_run", fake_job_run)
+
+    events = {"start": [], "finish": [], "error": []}
+
+    def fake_start_job_step(conn, job, step_code, etapa_id=None, message=None, data=None):
+        events["start"].append(
+            {
+                "step_code": step_code,
+                "message": message,
+                "data": data,
+            }
+        )
+
+    def fake_finish_job_step(conn, job, step_code, status, message=None, data=None):
+        events["finish"].append(
+            {
+                "step_code": step_code,
+                "status": status,
+                "message": message,
+                "data": data,
+            }
+        )
+
+    def fake_finish_job_step_error(conn, job, step_code, message=None, data=None):
+        events["error"].append(
+            {
+                "step_code": step_code,
+                "message": message,
+                "data": data,
+            }
+        )
+
+    monkeypatch.setattr(base_module, "start_job_step", fake_start_job_step)
+    monkeypatch.setattr(base_module, "finish_job_step", fake_finish_job_step)
+    monkeypatch.setattr(base_module, "finish_job_step_error", fake_finish_job_step_error)
+
+    return SimpleNamespace(connection=connection, events=events, handle_ref=handle_ref)
+
+
+def test_run_step_job_logs_success(_run_step_env) -> None:
+    env = _run_step_env
+
+    def callback(context):
+        return StepJobOutcome(
+            status="skipped",
+            data={"capturados": 5},
+            info_update={"summary": "Concluído"},
+        )
+
+    result = run_step_job(
+        step=Step.ETAPA_1,
+        job_name=Step.ETAPA_1,
+        callback=callback,
+        user_id="user",
+    )
+
+    assert isinstance(result, ServiceResult)
+    assert env.events["start"] == [
+        {"step_code": "ETAPA_1", "message": None, "data": None}
+    ]
+    assert env.events["error"] == []
+
+    assert len(env.events["finish"]) == 1
+    finish_event = env.events["finish"][0]
+    assert finish_event["status"] == "SKIPPED"
+    assert finish_event["message"] == "Concluído"
+    assert finish_event["data"] == {
+        "capturados": 5,
+        "info_update": {"summary": "Concluído"},
+    }
+    assert env.handle_ref["handle"].status == "SKIPPED"
+
+
+def test_run_step_job_logs_failure(_run_step_env) -> None:
+    env = _run_step_env
+
+    def callback(_context):
+        raise ValueError("Falhou geral")
+
+    with pytest.raises(ValueError):
+        run_step_job(
+            step=Step.ETAPA_2,
+            job_name=Step.ETAPA_2,
+            callback=callback,
+        )
+
+    assert len(env.events["start"]) == 1
+    assert env.events["finish"] == []
+    assert len(env.events["error"]) == 1
+    error_event = env.events["error"][0]
+    assert error_event["message"] == "Falhou geral"
+    assert error_event["data"]["attempt"] == 1
+    assert env.handle_ref["handle"].status == "ERROR"
+
+
+def test_run_step_job_retries_unique_violation(_run_step_env) -> None:
+    env = _run_step_env
+    attempts = {"count": 0}
+
+    def callback(_context):
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            raise UniqueViolation("dup")
+        return StepJobOutcome(
+            status="SUCCESS",
+            data={"ok": True},
+        )
+
+    result = run_step_job(
+        step=Step.ETAPA_3,
+        job_name=Step.ETAPA_3,
+        callback=callback,
+    )
+
+    assert isinstance(result, ServiceResult)
+    assert attempts["count"] == 3
+    assert len(env.events["start"]) == 3
+    assert len(env.events["error"]) == 2
+    assert env.events["error"][0]["data"]["attempt"] == 1
+    assert env.events["error"][1]["data"]["attempt"] == 2
+    assert len(env.events["finish"]) == 1
+    assert env.events["finish"][0]["status"] == "SUCCESS"
+    assert env.handle_ref["handle"].status == "SUCCESS"

--- a/tests/test_infra_audit.py
+++ b/tests/test_infra_audit.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from infra.audit import (
+    JobRunHandle,
+    job_step,
+    start_job_step,
+    finish_job_step,
+)
+
+
+def _make_cursor() -> tuple[MagicMock, MagicMock]:
+    cursor = MagicMock()
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = None
+    return cursor_cm, cursor
+
+
+def _make_connection(*cursors: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.side_effect = list(cursors)
+    return conn
+
+
+def _job_handle() -> JobRunHandle:
+    return JobRunHandle(
+        tenant_id="tenant",
+        started_at=datetime(2024, 1, 1, 12, 0, 0),
+        id="job-id",
+    )
+
+
+def test_start_job_step_inserts_record() -> None:
+    cursor_cm, cursor = _make_cursor()
+    conn = _make_connection(cursor_cm)
+    handle = _job_handle()
+
+    step_handle = start_job_step(
+        conn,
+        job=handle,
+        step_code="ETAPA_1",
+        message="  Captura inicial  ",
+        data={"total": 3},
+    )
+
+    conn.cursor.assert_called_once()
+    cursor.execute.assert_called_once()
+    sql, params = cursor.execute.call_args[0]
+    assert "INSERT INTO audit.job_step" in sql
+    assert params[0] == handle.tenant_id
+    assert params[3] == "ETAPA_1"
+    assert params[5] == "Captura inicial"
+    assert params[6].obj == {"total": 3}
+
+    assert step_handle.step_code == "ETAPA_1"
+    assert step_handle.message == "Captura inicial"
+    assert step_handle.data == {"total": 3}
+
+
+def test_finish_job_step_updates_status_and_message() -> None:
+    cursor_cm, cursor = _make_cursor()
+    conn = _make_connection(cursor_cm)
+    handle = _job_handle()
+
+    finish_job_step(
+        conn,
+        job=handle,
+        step_code="ETAPA_2",
+        status="skipped",
+        message="  Nada a fazer  ",
+        data=None,
+    )
+
+    conn.cursor.assert_called_once()
+    sql, params = cursor.execute.call_args[0]
+    assert "UPDATE audit.job_step" in sql
+    assert params[0] == "SKIPPED"
+    assert params[1] == "Nada a fazer"
+    assert params[2] is None
+
+
+def test_job_step_context_manager_marks_error() -> None:
+    start_cm, start_cursor = _make_cursor()
+    finish_cm, finish_cursor = _make_cursor()
+    conn = _make_connection(start_cm, finish_cm)
+    handle = _job_handle()
+
+    with pytest.raises(RuntimeError):
+        with job_step(conn, job=handle, step_code="ETAPA_3"):
+            raise RuntimeError("falhou")
+
+    # Segunda chamada corresponde à atualização de erro
+    assert conn.cursor.call_count == 2
+    sql, params = finish_cursor.execute.call_args[0]
+    assert "UPDATE audit.job_step" in sql
+    assert params[0] == "ERROR"
+    assert params[1] == "RuntimeError: falhou"


### PR DESCRIPTION
## Summary
- add helper utilities to register job_step executions and expose an optional context manager
- extend the pipeline runner to persist job_step lifecycle events and capture retry/error metadata
- cover the new behaviour with focused unit tests for audit helpers and run_step_job

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc1202b3148323b0c616733f333380