### PR TITLE
Ensure occurrences reflect non-passível plans

### DIFF
--- a/tests/services/test_gestao_base_persistence.py
+++ b/tests/services/test_gestao_base_persistence.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from services.gestao_base import persistence
+from services.gestao_base.models import GestaoBaseData, PlanRowEnriched
+
+
+@pytest.mark.parametrize(
+    "situacao",
+    [
+        "P.RESC",
+        "Passível Rescisão",
+        "Passivel de Rescisao",
+        "PASSIVELDERESCISAO",
+    ],
+)
+def test_should_not_register_occurrence_for_passivel_variations(situacao: str) -> None:
+    assert persistence._should_register_occurrence(situacao) is False
+
+
+@pytest.mark.parametrize(
+    "situacao",
+    [
+        "RESCINDIDO",
+        "LIQUIDADO",
+        "GRDE",
+        "P.RESC.LIQ",
+    ],
+)
+def test_should_register_occurrence_for_non_passivel_status(situacao: str) -> None:
+    assert persistence._should_register_occurrence(situacao) is True
+
+
+class _DummyPlansRepository:
+    def __init__(self) -> None:
+        self._store: dict[str, SimpleNamespace] = {}
+        self._counter = 0
+
+    def get_by_numero(self, numero: str) -> SimpleNamespace | None:
+        return self._store.get(numero)
+
+    def upsert(self, numero_plano: str, existing=None, **kwargs):
+        if existing is None:
+            self._counter += 1
+            plan = SimpleNamespace(id=str(self._counter), numero_plano=numero_plano, **kwargs)
+            self._store[numero_plano] = plan
+            return plan
+
+        existing.__dict__.update(kwargs)
+        self._store[numero_plano] = existing
+        return existing
+
+
+class _DummyEventsRepository:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, str]] = []
+
+    def log(self, plan_id, step, message):
+        self.calls.append((plan_id, step, message))
+
+
+def test_persist_rows_registers_occurrences_for_non_passivel(monkeypatch):
+    captured: list[dict[str, object]] = []
+
+    class _RecorderOccurrenceRepository:
+        def __init__(self, _db) -> None:  # pragma: no cover - interface compatibility
+            self._db = _db
+
+        def add(self, **payload):
+            captured.append(payload)
+
+    monkeypatch.setattr(persistence, "OccurrenceRepository", _RecorderOccurrenceRepository)
+    monkeypatch.setattr(persistence.settings, "DRY_RUN", False)
+
+    context = SimpleNamespace(
+        db=object(),
+        plans=_DummyPlansRepository(),
+        events=_DummyEventsRepository(),
+    )
+
+    rows = [
+        PlanRowEnriched(
+            numero="0000001",
+            dt_propost="01/01/2024",
+            tipo="Tipo A",
+            situac="P.RESC",
+            resoluc="R1",
+            razao_social="Empresa 1",
+            saldo_total="100,00",
+            cnpj="12.345.678/0001-90",
+        ),
+        PlanRowEnriched(
+            numero="0000002",
+            dt_propost="01/01/2024",
+            tipo="Tipo B",
+            situac="RESCINDIDO",
+            resoluc="R2",
+            razao_social="Empresa 2",
+            saldo_total="200,00",
+            cnpj="98.765.432/0001-10",
+        ),
+        PlanRowEnriched(
+            numero="0000003",
+            dt_propost="01/01/2024",
+            tipo="Tipo C",
+            situac="LIQUIDADO",
+            resoluc="R3",
+            razao_social="Empresa 3",
+            saldo_total="300,00",
+            cnpj="11.222.333/0001-44",
+        ),
+    ]
+
+    data = GestaoBaseData(rows=rows, raw_lines=[], portal_po=[], descartados_974=0)
+
+    result = persistence.persist_rows(context, data)
+
+    assert result["importados"] == 3
+    assert {item["numero_plano"] for item in captured} == {"0000002", "0000003"}
+    assert all(item["situacao"] in {"RESCINDIDO", "LIQUIDADO"} for item in captured)

--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -485,7 +485,7 @@ input:focus {
   color: #ffffff;
 }
 
-.section-switch--active .section-switch__count {
+.section-switch--active .section-switch__count:not(.section-switch__count--alert) {
   color: inherit;
 }
 
@@ -493,6 +493,11 @@ input:focus {
   margin-left: 8px;
   font-size: 13px;
   color: var(--primary);
+}
+
+.section-switch__count--alert {
+  color: #c53030;
+  font-weight: 600;
 }
 
 .badge {

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -431,6 +431,42 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  const setupOccurrencesCounter = () => {
+    const countElement = document.getElementById('occurrencesCount');
+    const occurrencesPanel = document.getElementById('occurrencesTablePanel');
+
+    if (!countElement || !occurrencesPanel) {
+      return;
+    }
+
+    const updateCount = () => {
+      const tbody = occurrencesPanel.querySelector('tbody');
+      const rows = tbody ? Array.from(tbody.rows ?? []) : [];
+      const total = rows.filter((row) => {
+        if (row.classList.contains('table__row--empty')) {
+          return false;
+        }
+        if (row.hasAttribute('hidden')) {
+          return false;
+        }
+        return true;
+      }).length;
+
+      countElement.textContent = `(${total})`;
+      countElement.classList.toggle('section-switch__count--alert', total > 0);
+    };
+
+    updateCount();
+
+    const observer = new MutationObserver(updateCount);
+    observer.observe(occurrencesPanel, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'hidden'],
+    });
+  };
+
   const setupTableSwitching = () => {
     const tabs = Array.from(document.querySelectorAll('[data-table-target]'));
     const panels = Array.from(document.querySelectorAll('[data-table-panel]'));
@@ -722,5 +758,6 @@ document.addEventListener('DOMContentLoaded', () => {
   updateAccordionState(false);
   setupCopyableCells();
   setupDocumentObserver();
+  setupOccurrencesCounter();
   setupTableSwitching();
 });


### PR DESCRIPTION
## Summary
- normalize plan status tokens so every non passível situação produces an occurrence during persistence
- update the web UI to monitor the occurrences table, refresh the counter badge, and highlight it in red when items exist
- add unit coverage for the new persistence logic to safeguard the registration rules

## Testing
- pytest tests/services/test_gestao_base_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68dc1de7133083238ed2a707de3ef9c5