### PR TITLE
feat: registrar auditoria detalhada da gestão da base

### DIFF
--- a/services/gestao_base/__init__.py
+++ b/services/gestao_base/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .collectors import DryRunCollector, GestaoBaseCollector, TerminalCollector
 from .models import (
     GestaoBaseData,
+    PipelineAuditHooks,
     PlanRow,
     PlanRowEnriched,
     ProgressCallback,
@@ -17,6 +18,7 @@ __all__ = [
     "GestaoBaseData",
     "GestaoBaseNoOpService",
     "GestaoBaseService",
+    "PipelineAuditHooks",
     "PlanRow",
     "PlanRowEnriched",
     "ProgressCallback",

--- a/services/gestao_base/audit.py
+++ b/services/gestao_base/audit.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from infra.audit import (
+    JobRunHandle,
+    finish_job_step_error,
+    finish_job_step_ok,
+    log_event,
+    start_job_step,
+)
+
+from services.base import StepJobContext
+
+from .models import PipelineAuditHooks
+
+
+def _normalize_data(payload: Optional[dict[str, Any]]) -> dict[str, Any]:
+    if not payload:
+        return {}
+    return dict(payload)
+
+
+@dataclass(slots=True)
+class GestaoBaseAuditManager:
+    """Controla a integração das etapas da Gestão da Base com o audit."""
+
+    context: StepJobContext
+    pipeline_name: str = "gestao_base"
+    _hooks: Optional["_GestaoBaseStageHooks"] = None
+
+    @property
+    def job(self) -> JobRunHandle:
+        return self.context.job
+
+    def create_stage_hooks(self) -> "_GestaoBaseStageHooks":
+        if self._hooks is None:
+            self._hooks = _GestaoBaseStageHooks(self)
+        return self._hooks
+
+    def log_event(
+        self,
+        event_type: str,
+        message: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+        *,
+        severity: str = "info",
+    ) -> None:
+        payload = _normalize_data(data)
+        payload.setdefault("job_id", self.job.id)
+        log_event(
+            self.context.db,
+            entity="pipeline",
+            entity_id=self.job.id,
+            event_type=event_type,
+            severity=severity,
+            message=message,
+            data=payload,
+        )
+        self.context.db.commit()
+
+    def stage_metrics(self) -> Dict[str, dict[str, Any]]:
+        hooks = self.create_stage_hooks()
+        return {code: dict(values) for code, values in hooks.metrics.items()}
+
+    def combined_metrics(self) -> dict[str, Any]:
+        metrics: dict[str, Any] = {}
+        for values in self.stage_metrics().values():
+            metrics.update(values)
+        return metrics
+
+    def merge_metrics(self, extra: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+        merged = self.combined_metrics()
+        if extra:
+            merged.update(extra)
+        return merged
+
+    def pipeline_started(
+        self,
+        data: Optional[dict[str, Any]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        default_message = message or "Gestão da Base iniciada"
+        self.log_event("PIPELINE_STARTED", default_message, data)
+
+    def pipeline_finished(
+        self,
+        extra_metrics: Optional[dict[str, Any]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        payload = self.merge_metrics(extra_metrics)
+        default_message = message or "Gestão da Base concluída"
+        self.log_event("PIPELINE_FINISHED", default_message, payload)
+
+    def pipeline_failed(
+        self,
+        error: BaseException,
+        *,
+        data: Optional[dict[str, Any]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        text = message or "Falha na Gestão da Base"
+        payload = self.merge_metrics(data)
+        err_text = str(error).strip() or error.__class__.__name__
+        payload.setdefault("error", err_text)
+        self.log_event("PIPELINE_FAILED", text, payload, severity="error")
+
+
+@dataclass(slots=True)
+class _GestaoBaseStageHooks(PipelineAuditHooks):
+    """Implementa ``PipelineAuditHooks`` integrando com o audit do banco."""
+
+    manager: GestaoBaseAuditManager
+    metrics: Dict[str, dict[str, Any]] = field(default_factory=dict)
+    _active_steps: set[str] = field(default_factory=set)
+
+    def stage_started(
+        self,
+        step_code: str,
+        message: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        start_job_step(
+            self.manager.context.db,
+            job=self.manager.job,
+            step_code=step_code,
+            message=message,
+            data=data,
+        )
+        self._active_steps.add(step_code)
+        event_message = message or f"Etapa {step_code} iniciada"
+        self.manager.log_event(
+            f"{step_code}_STARTED",
+            event_message,
+            data,
+        )
+
+    def stage_finished(
+        self,
+        step_code: str,
+        message: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        finish_job_step_ok(
+            self.manager.context.db,
+            job=self.manager.job,
+            step_code=step_code,
+            message=message,
+            data=data,
+        )
+        self.metrics[step_code] = _normalize_data(data)
+        self._active_steps.discard(step_code)
+        event_message = message or f"Etapa {step_code} concluída"
+        self.manager.log_event(
+            f"{step_code}_FINISHED",
+            event_message,
+            data,
+        )
+
+    def stage_failed(
+        self,
+        step_code: str,
+        error: str,
+        *,
+        data: Optional[dict[str, Any]] = None,
+        message: Optional[str] = None,
+    ) -> None:
+        finish_job_step_error(
+            self.manager.context.db,
+            job=self.manager.job,
+            step_code=step_code,
+            message=error,
+            data=data,
+        )
+        self._active_steps.discard(step_code)
+        payload = _normalize_data(data)
+        payload.setdefault("error", error)
+        event_message = message or f"Etapa {step_code} falhou"
+        self.manager.log_event(
+            f"{step_code}_FAILED",
+            event_message,
+            payload,
+            severity="error",
+        )
+
+
+__all__ = ["GestaoBaseAuditManager"]
+

--- a/services/gestao_base/collectors.py
+++ b/services/gestao_base/collectors.py
@@ -5,7 +5,13 @@ from typing import Callable, List, Optional
 
 from services.pw3270 import PW3270
 
-from .models import GestaoBaseCollector, GestaoBaseData, PlanRowEnriched, ProgressCallback
+from .models import (
+    GestaoBaseCollector,
+    GestaoBaseData,
+    PipelineAuditHooks,
+    PlanRowEnriched,
+    ProgressCallback,
+)
 from .pipeline import run_pipeline
 from .portal import portal_po_provider
 from .terminal import session
@@ -43,14 +49,63 @@ def _sample_data() -> GestaoBaseData:
 
 
 class DryRunCollector(GestaoBaseCollector):
-    def collect(self, progress: Optional[ProgressCallback] = None) -> GestaoBaseData:
+    def collect(
+        self,
+        progress: Optional[ProgressCallback] = None,
+        audit_hooks: Optional[PipelineAuditHooks] = None,
+    ) -> GestaoBaseData:
         logger.info("Executando coleta de Gestão da Base em modo dry-run")
         if progress:
             progress(10.0, None, "Captura simulada iniciada")
             progress(35.0, 1, "Dados simulados coletados")
             progress(50.0, 2, "Situação especial simulada aplicada")
             progress(65.0, 3, "Dados simulados enriquecidos")
-        return _sample_data()
+        data = _sample_data()
+        if audit_hooks:
+            audit_hooks.stage_started(
+                "CAPTURA_PLANOS", "Captura simulada de Planos", data={}
+            )
+            capture_metrics = {
+                "capturados_total": len(data.rows),
+                "descartados_974": data.descartados_974,
+                "erros_parse": len(data.raw_lines),
+            }
+            audit_hooks.stage_finished(
+                "CAPTURA_PLANOS", "Captura simulada concluída", capture_metrics
+            )
+
+            audit_hooks.stage_started(
+                "SITUACAO_ESPECIAL",
+                "Portal PO simulado",
+                data={"qtde_po_capturados": len(data.portal_po)},
+            )
+            sit_especial = sum(
+                1
+                for row in data.rows
+                if (row.situac or "").upper().startswith("SIT. ESPECIAL")
+            )
+            audit_hooks.stage_finished(
+                "SITUACAO_ESPECIAL",
+                "Situação especial simulada concluída",
+                {
+                    "qtde_po_capturados": len(data.portal_po),
+                    "sit_especial": sit_especial,
+                },
+            )
+
+            audit_hooks.stage_started(
+                "GUIA_GRDE", "Verificação GRDE simulada", data={}
+            )
+            grde_emitida = sum(1 for row in data.rows if row.situac == "GRDE Emitida")
+            audit_hooks.stage_finished(
+                "GUIA_GRDE",
+                "Verificação GRDE simulada concluída",
+                {
+                    "qtde_grde_emitida": grde_emitida,
+                    "qtde_grde_nao_emitida": len(data.rows) - grde_emitida,
+                },
+            )
+        return data
 
 
 class TerminalCollector(GestaoBaseCollector):  # pragma: no cover - integrações reais
@@ -62,7 +117,11 @@ class TerminalCollector(GestaoBaseCollector):  # pragma: no cover - integraçõe
         self.senha = senha
         self.portal_provider = portal_provider or portal_po_provider
 
-    def collect(self, progress: Optional[ProgressCallback] = None) -> GestaoBaseData:
+    def collect(
+        self,
+        progress: Optional[ProgressCallback] = None,
+        audit_hooks: Optional[PipelineAuditHooks] = None,
+    ) -> GestaoBaseData:
         assert PW3270 is not None
         pw = PW3270()
         with session(pw):
@@ -71,4 +130,5 @@ class TerminalCollector(GestaoBaseCollector):  # pragma: no cover - integraçõe
                 self.senha,
                 portal_provider=self.portal_provider,
                 progress=progress,
+                audit_hooks=audit_hooks,
             )

--- a/services/gestao_base/models.py
+++ b/services/gestao_base/models.py
@@ -40,5 +40,37 @@ ProgressCallback = Callable[[float, Optional[int], Optional[str]], None]
 
 
 class GestaoBaseCollector(Protocol):
-    def collect(self, progress: Optional[ProgressCallback] = None) -> GestaoBaseData:
+    def collect(
+        self,
+        progress: Optional[ProgressCallback] = None,
+        audit_hooks: Optional["PipelineAuditHooks"] = None,
+    ) -> GestaoBaseData:
+        ...
+
+
+class PipelineAuditHooks(Protocol):
+    def stage_started(
+        self,
+        step_code: str,
+        message: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        ...
+
+    def stage_finished(
+        self,
+        step_code: str,
+        message: Optional[str] = None,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        ...
+
+    def stage_failed(
+        self,
+        step_code: str,
+        error: str,
+        *,
+        data: Optional[dict[str, Any]] = None,
+        message: Optional[str] = None,
+    ) -> None:
         ...

--- a/services/gestao_base/pipeline.py
+++ b/services/gestao_base/pipeline.py
@@ -4,7 +4,7 @@ import logging
 from typing import Callable, List, Optional
 
 from .constants import MSG_FIM_BLOCO, MSG_ULTIMA_PAGINA, RESOLUCAO_DESCARTAR
-from .models import GestaoBaseData, PlanRow, ProgressCallback
+from .models import GestaoBaseData, PlanRow, ProgressCallback, PipelineAuditHooks
 from .portal import aplica_sit_especial, build_tipo_map
 from .terminal import (
     enrich_on_e527,
@@ -27,6 +27,7 @@ def run_pipeline(
     portal_provider: Optional[Callable[[], List[dict]]] = None,
     *,
     progress: Optional[ProgressCallback] = None,
+    audit_hooks: Optional[PipelineAuditHooks] = None,
 ) -> GestaoBaseData:  # pragma: no cover - integrações reais
     if progress:
         progress(5.0, None, "Estabelecendo sessão no terminal")
@@ -39,36 +40,69 @@ def run_pipeline(
     raw_lines: List[str] = []
     all_rows: List[PlanRow] = []
 
-    while True:
-        blocos += 1
-        logger.info("Iniciando bloco %s", blocos)
-        footer_after_last: Optional[str] = None
-        for page_lines, (_x, y, z), footer in iterate_e555_pages(pw):
-            for line in page_lines:
-                parsed = parse_line(line)
-                if parsed:
-                    all_rows.append(parsed)
-                else:
-                    raw_lines.append(line)
-            if footer is not None:
-                footer_after_last = footer
+    capture_step = "CAPTURA_PLANOS"
+    if audit_hooks:
+        audit_hooks.stage_started(capture_step, "Iniciando Captura de Planos")
 
-        footer_after_last = (footer_after_last or "").strip()
-        if MSG_FIM_BLOCO in footer_after_last:
-            logger.info("Fim do bloco, avançando para próximo bloco")
-            pf(pw, 11)
-            continue
-        if MSG_ULTIMA_PAGINA in footer_after_last:
-            logger.info("Última página, encerrando coleta da E555")
+    erros_parse = 0
+
+    try:
+        while True:
+            blocos += 1
+            logger.info("Iniciando bloco %s", blocos)
+            footer_after_last: Optional[str] = None
+            for page_lines, (_x, y, z), footer in iterate_e555_pages(pw):
+                for line in page_lines:
+                    parsed = parse_line(line)
+                    if parsed:
+                        all_rows.append(parsed)
+                    else:
+                        raw_lines.append(line)
+                        erros_parse += 1
+                if footer is not None:
+                    footer_after_last = footer
+
+            footer_after_last = (footer_after_last or "").strip()
+            if MSG_FIM_BLOCO in footer_after_last:
+                logger.info("Fim do bloco, avançando para próximo bloco")
+                pf(pw, 11)
+                continue
+            if MSG_ULTIMA_PAGINA in footer_after_last:
+                logger.info("Última página, encerrando coleta da E555")
+                break
+            if footer_after_last:
+                logger.warning("Mensagem inesperada no rodapé: %r", footer_after_last)
             break
-        if footer_after_last:
-            logger.warning("Mensagem inesperada no rodapé: %r", footer_after_last)
-        break
+    except Exception as exc:
+        if audit_hooks:
+            audit_hooks.stage_failed(
+                capture_step,
+                f"Falha na captura de planos: {exc}",
+                data={"capturados_total": len(all_rows), "erros_parse": erros_parse},
+            )
+        raise
 
     dados_filtrados = [row for row in all_rows if row.resoluc != RESOLUCAO_DESCARTAR]
     descartados_974 = len(all_rows) - len(dados_filtrados)
+    capture_metrics = {
+        "capturados_total": len(dados_filtrados),
+        "descartados_974": descartados_974,
+        "erros_parse": erros_parse,
+    }
+    if audit_hooks:
+        audit_hooks.stage_finished(
+            capture_step,
+            "Captura concluída",
+            capture_metrics,
+        )
     if progress:
         progress(25.0, 1, f"{len(dados_filtrados)} planos capturados na E555")
+
+    portal_step = "SITUACAO_ESPECIAL"
+    if audit_hooks:
+        audit_hooks.stage_started(
+            portal_step, "Verificando Situação Especial (Portal PO)"
+        )
 
     portal_po: list[dict] = []
 
@@ -79,22 +113,74 @@ def run_pipeline(
     except Exception as exc:  # pragma: no cover - defensivo
         logger.warning("Falha ao obter Portal PO: %s", exc)
         portal_po = []
+
     if progress:
         progress(35.0, 2, "Dados do Portal PO integrados")
 
     tipos_map = build_tipo_map(portal_po) if portal_po else {}
 
-    dados_ajustados: List[PlanRow] = (
-        aplica_sit_especial(dados_filtrados, tipos_map)
-        if tipos_map
-        else list(dados_filtrados)
+    dados_ajustados: List[PlanRow] = []
+    try:
+        dados_ajustados = (
+            aplica_sit_especial(dados_filtrados, tipos_map)
+            if tipos_map
+            else list(dados_filtrados)
+        )
+    except Exception as exc:
+        if audit_hooks:
+            audit_hooks.stage_failed(
+                portal_step,
+                f"Falha ao aplicar situação especial: {exc}",
+                data={"qtde_po_capturados": len(portal_po)},
+            )
+        raise
+
+    sit_especial = sum(
+        1 for row in dados_ajustados if "SIT. ESPECIAL" in (row.situac or "")
     )
+    portal_metrics = {
+        "qtde_po_capturados": len(portal_po),
+        "sit_especial": sit_especial,
+    }
+    if audit_hooks:
+        audit_hooks.stage_finished(
+            portal_step,
+            "Portal PO processado",
+            portal_metrics,
+        )
 
     open_e527(pw)
     enriched = enrich_on_e527(pw, dados_ajustados)
 
-    open_e50h(pw)
-    enriched = search_grde(pw, enriched)
+    guia_step = "GUIA_GRDE"
+    if audit_hooks:
+        audit_hooks.stage_started(
+            guia_step, "Verificando GRDE (e50h)", data={"planos": len(enriched)}
+        )
+
+    try:
+        open_e50h(pw)
+        enriched = search_grde(pw, enriched)
+    except Exception as exc:
+        if audit_hooks:
+            audit_hooks.stage_failed(
+                guia_step,
+                f"Falha na verificação de GRDE: {exc}",
+                data={"planos": len(enriched)},
+            )
+        raise
+
+    grde_emitida = sum(1 for row in enriched if row.situac == "GRDE Emitida")
+    guia_metrics = {
+        "qtde_grde_emitida": grde_emitida,
+        "qtde_grde_nao_emitida": len(enriched) - grde_emitida,
+    }
+    if audit_hooks:
+        audit_hooks.stage_finished(
+            guia_step,
+            "Verificação GRDE concluída",
+            guia_metrics,
+        )
 
     if progress:
         progress(50.0, 3, "Enriquecimento na E527 concluído")


### PR DESCRIPTION
## Summary
- implement a dedicated audit manager for the gestão da base pipeline to control job steps and pipeline events with metrics
- update collectors and pipeline flows to emit CAPTURA_PLANOS, SITUACAO_ESPECIAL and GUIA_GRDE metrics and events
- expose the job handle in the service context so the service can wire audit hooks and register pipeline lifecycle events

## Testing
- pytest *(fails: missing psycopg/fastapi dependencies in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc28fa412483239572086d3613e00d