### PR TITLE
Handle passível tokens with trailing descriptors

### DIFF
--- a/services/gestao_base/persistence.py
+++ b/services/gestao_base/persistence.py
@@ -95,6 +95,12 @@ def _tokens_indicate_passivel_rescisao(tokens: list[str]) -> bool:
             continue
         if token.startswith("RESC") and token not in {"RESC", "RESCISAO"}:
             return False
+        if token.startswith("LIQ") or token == "GRDE" or token.startswith("ESPECIAL"):
+            return False
+        if saw_passivel_component:
+            # After identifying a passível component we allow extra descriptors
+            # (e.g. "EM", "ANALISE", "DEFERIDA") without invalidating the match.
+            continue
         return False
 
     has_abbreviation = any(token.startswith("PRESC") for token in tokens)

--- a/tests/services/test_gestao_base_persistence.py
+++ b/tests/services/test_gestao_base_persistence.py
@@ -22,6 +22,8 @@ from services.gestao_base.models import GestaoBaseData, PlanRowEnriched
         "Passível Rescisão",
         "Passivel de Rescisao",
         "PASSIVELDERESCISAO",
+        "Passível de Rescisão Deferida",
+        "Passivel Rescisao Em Analise",
     ],
 )
 def test_should_not_register_occurrence_for_passivel_variations(situacao: str) -> None:


### PR DESCRIPTION
## Summary
- allow the passível rescisão token parser to ignore trailing qualifiers after a valid match while still rejecting LIQ/GRDE/ESPECIAL tokens
- expand the gestao_base persistence tests to cover passível statuses that include descriptors

## Testing
- pytest tests/services/test_gestao_base_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68dc2ca415688323b709773873323c6b