### PR TITLE
Add plan search API and UI enhancements

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -442,8 +442,17 @@ input:focus {
 }
 
 .section-title--tables {
-  justify-content: flex-start;
+  justify-content: space-between;
+  align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
+}
+
+.section-switch-group {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .section-title__heading {
@@ -498,6 +507,67 @@ input:focus {
 .section-switch__count--alert {
   color: #c53030;
   font-weight: 600;
+}
+
+.table-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f3f4f6;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 10px 6px 14px;
+  transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.table-search:focus-within {
+  border-color: var(--primary);
+  background: #ffffff;
+}
+
+.table-search__input {
+  border: none;
+  background: transparent;
+  font-size: 14px;
+  min-width: 200px;
+  color: var(--text);
+}
+
+.table-search__input::placeholder {
+  color: var(--muted-light);
+}
+
+.table-search__input:focus {
+  outline: none;
+}
+
+.table-search__button {
+  border: none;
+  background: transparent;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary);
+  cursor: pointer;
+  border-radius: 999px;
+}
+
+.table-search__button:hover,
+.table-search__button:focus {
+  background: rgba(16, 140, 188, 0.12);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .badge {

--- a/ui/index.html
+++ b/ui/index.html
@@ -61,36 +61,85 @@
             <div class="progress__bar"></div>
           </div>
 
-          <div
-            class="section-title section-title--tables"
-            role="tablist"
-            aria-label="Listas de planos"
-          >
-            <button
-              class="section-switch section-switch--active"
-              id="plansTableTab"
-              type="button"
-              role="tab"
-              aria-selected="true"
-              aria-controls="plansTablePanel"
-              data-table-target="plans"
-              tabindex="0"
+          <div class="section-title section-title--tables">
+            <div
+              class="section-switch-group"
+              role="tablist"
+              aria-label="Listas de planos"
             >
-              TABELA DE PLANOS
-            </button>
-            <button
-              class="section-switch"
-              id="occurrencesTableTab"
-              type="button"
-              role="tab"
-              aria-selected="false"
-              aria-controls="occurrencesTablePanel"
-              data-table-target="occurrences"
-              tabindex="-1"
+              <button
+                class="section-switch section-switch--active"
+                id="plansTableTab"
+                type="button"
+                role="tab"
+                aria-selected="true"
+                aria-controls="plansTablePanel"
+                data-table-target="plans"
+                tabindex="0"
+              >
+                TABELA DE PLANOS
+              </button>
+              <button
+                class="section-switch"
+                id="occurrencesTableTab"
+                type="button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="occurrencesTablePanel"
+                data-table-target="occurrences"
+                tabindex="-1"
+              >
+                OCORRÊNCIAS
+                <span class="section-switch__count" id="occurrencesCount">(0)</span>
+              </button>
+            </div>
+
+            <form
+              class="table-search"
+              id="plansSearchForm"
+              role="search"
+              data-table-search="plans"
+              autocomplete="off"
             >
-              OCORRÊNCIAS
-              <span class="section-switch__count" id="occurrencesCount">(0)</span>
-            </button>
+              <label class="sr-only" for="plansSearchInput"
+                >Buscar por número, razão social ou CNPJ/CEI</label
+              >
+              <input
+                class="table-search__input"
+                type="search"
+                id="plansSearchInput"
+                name="q"
+                placeholder="Buscar plano"
+                aria-label="Buscar plano por número, razão social ou CNPJ/CEI"
+              />
+              <button class="table-search__button" type="submit" aria-label="Buscar">
+                <i data-feather="search" aria-hidden="true"></i>
+              </button>
+            </form>
+
+            <form
+              class="table-search"
+              id="occurrencesSearchForm"
+              role="search"
+              data-table-search="occurrences"
+              autocomplete="off"
+              hidden
+            >
+              <label class="sr-only" for="occurrencesSearchInput"
+                >Buscar ocorrência por número, razão social ou CNPJ/CEI</label
+              >
+              <input
+                class="table-search__input"
+                type="search"
+                id="occurrencesSearchInput"
+                name="q"
+                placeholder="Buscar ocorrência"
+                aria-label="Buscar ocorrência por número, razão social ou CNPJ/CEI"
+              />
+              <button class="table-search__button" type="submit" aria-label="Buscar">
+                <i data-feather="search" aria-hidden="true"></i>
+              </button>
+            </form>
           </div>
 
           <div


### PR DESCRIPTION
## Summary
- add queryable endpoints for plans, including number, document and name searches backed by app.vw_planos_busca
- introduce a search bar for the plans and occurrences tables with refreshed layout styles
- hook the dashboard up to the new backend search and apply client-side filtering for occurrences

## Testing
- pytest *(fails: missing psycopg/fastapi test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5aa4804c832391c69933e0ed50a5