### PR TITLE
Unify table search input across plans and occurrences

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -96,45 +96,20 @@
 
             <form
               class="table-search"
-              id="plansSearchForm"
+              id="tableSearchForm"
               role="search"
-              data-table-search="plans"
               autocomplete="off"
             >
-              <label class="sr-only" for="plansSearchInput"
-                >Buscar por número, razão social ou CNPJ/CEI</label
+              <label class="sr-only" for="tableSearchInput"
+                >Digite o número do plano, CNPJ/CEI ou razão social…</label
               >
               <input
                 class="table-search__input"
                 type="search"
-                id="plansSearchInput"
+                id="tableSearchInput"
                 name="q"
-                placeholder="Buscar plano"
-                aria-label="Buscar plano por número, razão social ou CNPJ/CEI"
-              />
-              <button class="table-search__button" type="submit" aria-label="Buscar">
-                <i data-feather="search" aria-hidden="true"></i>
-              </button>
-            </form>
-
-            <form
-              class="table-search"
-              id="occurrencesSearchForm"
-              role="search"
-              data-table-search="occurrences"
-              autocomplete="off"
-              hidden
-            >
-              <label class="sr-only" for="occurrencesSearchInput"
-                >Buscar ocorrência por número, razão social ou CNPJ/CEI</label
-              >
-              <input
-                class="table-search__input"
-                type="search"
-                id="occurrencesSearchInput"
-                name="q"
-                placeholder="Buscar ocorrência"
-                aria-label="Buscar ocorrência por número, razão social ou CNPJ/CEI"
+                placeholder="Digite o número do plano, CNPJ/CEI ou razão social…"
+                aria-label="Digite o número do plano, CNPJ/CEI ou razão social…"
               />
               <button class="table-search__button" type="submit" aria-label="Buscar">
                 <i data-feather="search" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- replace the separate plans and occurrences search forms with a single shared search bar
- update the table switching logic to reuse the active search term for each table and apply the correct handler
- set the placeholder to "Digite o número do plano, CNPJ/CEI ou razão social…" for the unified input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5f5888f0832397c647c7a0c3cf9b