### PR TITLE
Guard audit job steps against non-mapping payloads

### DIFF
--- a/infra/audit.py
+++ b/infra/audit.py
@@ -191,7 +191,11 @@ def start_job_step(
     normalized_message = _normalize_message(message)
     payload = _load_job_payload(conn, job)
 
-    steps = payload.setdefault("steps", {})
+    steps_value = payload.get("steps")
+    if not isinstance(steps_value, dict):
+        steps_value = {}
+    steps = steps_value
+    payload["steps"] = steps
     step_entry = steps.get(step_code, {})
     step_entry.update(
         {
@@ -244,7 +248,11 @@ def finish_job_step(
     normalized_message = _normalize_message(message)
     payload = _load_job_payload(conn, job)
 
-    steps = payload.setdefault("steps", {})
+    steps_value = payload.get("steps")
+    if not isinstance(steps_value, dict):
+        steps_value = {}
+    steps = steps_value
+    payload["steps"] = steps
     step_entry = steps.get(step_code, {})
     step_entry["status"] = final_status
     step_entry["finished_at"] = _utcnow_iso()


### PR DESCRIPTION
## Summary
- coerce audit job payloads with non-mapping "steps" entries into empty dicts before updating
- apply the same safeguard when finishing job steps to avoid AttributeError

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc6bebaf3c8323a1e2646e08548474