### PR TITLE
Reduce event log header height

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -816,6 +816,11 @@ input:focus {
   flex-wrap: wrap;
 }
 
+.accordion--compact .accordion__header {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
 .accordion__toggle {
   display: flex;
   align-items: center;

--- a/ui/index.html
+++ b/ui/index.html
@@ -207,7 +207,7 @@
             </div>
           </div>
 
-          <div class="accordion">
+          <div class="accordion accordion--compact">
             <div class="accordion__header">
               <button
                 class="accordion__toggle"


### PR DESCRIPTION
## Summary
- add a compact accordion variant with reduced header padding
- apply the compact style to the event log window header

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc6fedcf74832384d3d8924c809204