### PR TITLE
Redirect root endpoint to login page

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -47,7 +47,7 @@ def create_app() -> FastAPI:
 
     @app.get("/", include_in_schema=False)
     async def root() -> RedirectResponse:
-        return RedirectResponse(url="/app/")
+        return RedirectResponse(url="/app/login.html")
 
     return app
 


### PR DESCRIPTION
## Summary
- update the root FastAPI route to send unauthenticated requests directly to `/app/login.html`
- confirm no other code paths relied on the previous `/app/` redirect

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc717793088323bdb064ae5dd4fcf4