### PR TITLE
Handle unauthorized plan session binding errors

### DIFF
--- a/api/routers/plans.py
+++ b/api/routers/plans.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from psycopg import AsyncConnection
+from psycopg.errors import InvalidAuthorizationSpecification
 from psycopg.rows import dict_row
 
 from api.models import PlanSummaryResponse, PlansResponse
@@ -258,6 +259,12 @@ async def list_plans(
                 limit=limit,
                 offset=offset,
             )
+    except (PermissionError, InvalidAuthorizationSpecification) as exc:
+        logger.exception("Erro ao carregar planos do banco de dados")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Credenciais de acesso inválidas.",
+        ) from exc
     except Exception as exc:  # pragma: no cover - defensive programming
         logger.exception("Erro ao carregar planos do banco de dados")
         raise HTTPException(


### PR DESCRIPTION
## Summary
- return HTTP 401 when plan session binding raises PermissionError or InvalidAuthorizationSpecification while keeping the existing logging
- add a regression test ensuring the plans router surfaces the 401 response when bind_session fails with a permission error

## Testing
- pytest tests/api/test_plans_router.py::test_list_plans_returns_unauthorized_when_binding_fails

------
https://chatgpt.com/codex/tasks/task_e_68dc77b0e78c83238fef1671d829b55a