### PR TITLE
Add redirect handler for /app path

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -37,6 +37,12 @@ def create_app() -> FastAPI:
 
     app.state.pipeline_orchestrator = PipelineOrchestrator()
 
+    @app.get("/app", include_in_schema=False)
+    async def app_redirect() -> RedirectResponse:
+        """Ensure `/app` always resolves to the static app index with trailing slash."""
+
+        return RedirectResponse(url="/app/")
+
     static_dir = Path(__file__).resolve().parents[1] / "ui"
     static_handler = (
         NoCacheStaticFiles(directory=static_dir, html=True)


### PR DESCRIPTION
## Summary
- register a `/app` GET handler that redirects to `/app/` before mounting the static UI to preserve relative asset paths

## Testing
- `pytest` *(fails: tests/infra/test_plans_repository.py::test_registrar_historico_insere_quando_situacao_altera, tests/infra/test_plans_repository.py::test_upsert_registra_historico_quando_informado due to timezone-sensitive expectations unrelated to the redirect)*
- Manual verification with `uvicorn api.app:create_app --host 0.0.0.0 --port 8000`, confirming `/app` redirects to `/app/` and static assets load

------
https://chatgpt.com/codex/tasks/task_e_68dd03ed17f083238fa562ecb46e03ea