### PR TITLE
Refactor shared only_digits helper usage

### DIFF
--- a/infra/repositories/_helpers.py
+++ b/infra/repositories/_helpers.py
@@ -4,6 +4,8 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any, Optional
 
+from shared.text import only_digits
+
 
 def calcular_atraso_desde(dias_em_atraso: Any) -> Optional[date]:
     """Converte dias em atraso para a data correspondente."""
@@ -67,14 +69,6 @@ def normalizar_situacao(texto: str) -> str:
     if normalizado.startswith("RESC") or "RESCINDIDO" in normalizado:
         return "RESCINDIDO"
     return "EM_DIA"
-
-
-def only_digits(valor: Any) -> str:
-    """Extrai somente os dígitos de um valor."""
-
-    return "".join(ch for ch in str(valor or "") if ch.isdigit())
-
-
 def safe_int(valor: Any) -> Optional[int]:
     """Converte valores textuais em inteiros de forma segura."""
 

--- a/services/gestao_base/utils.py
+++ b/services/gestao_base/utils.py
@@ -5,9 +5,7 @@ import re
 from datetime import date, datetime
 from typing import Any, Optional
 
-
-def only_digits(raw: str | None) -> str:
-    return re.sub(r"\D", "", raw or "")
+from shared.text import only_digits
 
 
 def parse_date_any(raw: str | None) -> Optional[date]:

--- a/shared/text.py
+++ b/shared/text.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["only_digits"]
+
+
+def only_digits(value: Any) -> str:
+    """Return the digits extracted from ``value`` as a contiguous string."""
+
+    return "".join(character for character in str(value or "") if character.isdigit())


### PR DESCRIPTION
## Summary
- add a shared text utility module exposing `only_digits`
- reuse the shared helper in gestao base utils and infra repository helpers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'psycopg'; FastAPI missing as well in test env)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0566bda88323a5d9e0c25211bd23