### PR TITLE
Centralize document normalization logic

### DIFF
--- a/api/routers/plans.py
+++ b/api/routers/plans.py
@@ -18,6 +18,7 @@ from infra.repositories._helpers import (
     to_decimal,
 )
 from shared.config import get_principal_settings
+from shared.text import normalize_document
 
 logger = logging.getLogger(__name__)
 
@@ -132,13 +133,7 @@ def _normalize_balance(value: Any) -> Decimal | None:
 def _normalize_document(value: Any) -> str | None:
     """Return a cleaned document identifier (digits only when available)."""
 
-    if value is None:
-        return None
-    digits = only_digits(value)
-    texto = str(value).strip()
-    if digits:
-        return digits
-    return texto or None
+    return normalize_document(value)
 
 
 def _row_to_plan_summary(row: dict[str, Any]) -> PlanSummaryResponse:

--- a/infra/repositories/occurrences.py
+++ b/infra/repositories/occurrences.py
@@ -8,8 +8,7 @@ from psycopg import Connection
 from psycopg.rows import dict_row
 
 from infra.audit import log_event
-
-from ._helpers import only_digits
+from shared.text import normalize_document
 
 
 class OccurrenceRepository:
@@ -37,7 +36,7 @@ class OccurrenceRepository:
                 return
 
             mensagem = f"Ocorrência {situacao} para plano {numero_plano}"
-            documento = only_digits(cnpj) or (cnpj or "").strip() or None
+            documento = normalize_document(cnpj)
             if isinstance(saldo, Decimal):
                 saldo_json: Optional[str | float] = str(saldo)
             else:

--- a/infra/repositories/plans.py
+++ b/infra/repositories/plans.py
@@ -8,6 +8,8 @@ from typing import Any, Iterable, Optional
 from psycopg import Connection
 from psycopg.rows import dict_row
 
+from shared.text import normalize_document
+
 from ._helpers import (
     calcular_atraso_desde,
     extract_date_from_timestamp,
@@ -173,7 +175,7 @@ class PlansRepository:
         if not numero:
             return campos.get("empregador_id")
 
-        numero_normalizado = self._only_digits(numero) or str(numero).strip()
+        numero_normalizado = normalize_document(numero)
         if not numero_normalizado:
             return campos.get("empregador_id")
 

--- a/services/gestao_base/persistence.py
+++ b/services/gestao_base/persistence.py
@@ -11,18 +11,18 @@ from domain.enums import PlanStatus, Step
 from infra.config import settings
 from infra.repositories import OccurrenceRepository
 from services.base import StepJobContext
+from shared.text import normalize_document
 
 from .models import GestaoBaseData, ProgressCallback
 from .parcelas import normalize_parcelas_atraso
-from .utils import only_digits, parse_date_any, parse_money_brl
+from .utils import parse_date_any, parse_money_brl
 
 logger = logging.getLogger(__name__)
 
 
 def clean_inscricao(raw: str | None) -> str:
-    texto = (raw or "").strip()
-    digits = only_digits(texto)
-    return digits or texto
+    normalized = normalize_document(raw, allow_empty=True)
+    return normalized if normalized is not None else ""
 
 
 def _representacao_value(raw: str | None, fallback: str | None) -> str | None:

--- a/shared/text.py
+++ b/shared/text.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+__all__ = ["only_digits", "normalize_document"]
+
+
+def only_digits(value: Any) -> str:
+    """Return only the numeric characters found in ``value``."""
+
+    return re.sub(r"\D", "", str(value or ""))
+
+
+def normalize_document(value: Any, *, allow_empty: bool = False) -> str | None:
+    """Normalize document identifiers removing extra characters and whitespace.
+
+    When ``allow_empty`` is ``True`` an empty string is returned instead of
+    ``None`` when no meaningful content is found.
+    """
+
+    text = str(value or "").strip()
+    digits = only_digits(value)
+
+    if digits:
+        return digits
+
+    if text:
+        return text
+
+    if allow_empty:
+        return ""
+
+    return None


### PR DESCRIPTION
## Summary
- add a shared `normalize_document` helper that builds on the existing digit filtering
- update plans API, services persistence, and infra repositories to reuse the centralized normalization

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'psycopg')*

------
https://chatgpt.com/codex/tasks/task_e_68dd057b1e2c8323b53e52531fe130b4