### PR TITLE
refactor: centralize API connection dependency

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,0 +1,18 @@
+"""Shared dependencies for the API layer."""
+
+from __future__ import annotations
+
+from contextlib import AbstractAsyncContextManager
+
+from psycopg import AsyncConnection
+
+from infra.db import get_connection
+
+
+def get_connection_manager() -> AbstractAsyncContextManager[AsyncConnection]:
+    """Return the shared database connection context manager."""
+
+    return get_connection()
+
+
+__all__ = ["get_connection_manager"]

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import logging
-from contextlib import AbstractAsyncContextManager
 
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
-from psycopg import AsyncConnection
 from psycopg.errors import InvalidAuthorizationSpecification
 
-from infra.db import bind_session, get_connection
+from api.dependencies import get_connection_manager
+from infra.db import bind_session
 
 logger = logging.getLogger(__name__)
 
@@ -27,18 +26,11 @@ class LoginResponse(BaseModel):
 
     matricula: str
 
-
-def _get_connection_manager() -> AbstractAsyncContextManager[AsyncConnection]:
-    """Return the connection context manager used to authenticate."""
-
-    return get_connection()
-
-
 @router.post("/login", response_model=LoginResponse)
 async def login(payload: LoginPayload) -> LoginResponse:
     """Autentica o usuário verificando a matrícula no banco de dados."""
 
-    connection_manager = _get_connection_manager()
+    connection_manager = get_connection_manager()
 
     try:
         async with connection_manager as connection:

--- a/api/routers/plans.py
+++ b/api/routers/plans.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from contextlib import AbstractAsyncContextManager
 from decimal import Decimal
 from typing import Any
 
@@ -11,7 +10,8 @@ from psycopg.errors import InvalidAuthorizationSpecification
 from psycopg.rows import dict_row
 
 from api.models import PlanSummaryResponse, PlansResponse
-from infra.db import bind_session, get_connection
+from api.dependencies import get_connection_manager
+from infra.db import bind_session
 from infra.repositories._helpers import (
     extract_date_from_timestamp,
     only_digits,
@@ -91,17 +91,6 @@ PLAN_SEARCH_BY_DOCUMENT_QUERY = """
 
 DEFAULT_LIMIT = 50
 MAX_LIMIT = 200
-
-
-def _get_connection_manager() -> AbstractAsyncContextManager[AsyncConnection]:
-    """Return the connection manager used by this router.
-
-    The indirection allows tests to patch the dependency easily.
-    """
-
-    return get_connection()
-
-
 _REQUEST_PRINCIPAL_HEADER_CANDIDATES = (
     "x-user-registration",
     "x-user-id",
@@ -257,7 +246,7 @@ async def list_plans(
             detail="Credenciais de acesso ausentes.",
         )
 
-    connection_manager = _get_connection_manager()
+    connection_manager = get_connection_manager()
     try:
         async with connection_manager as connection:
             await bind_session(connection, matricula)

--- a/tests/api/test_plans_router.py
+++ b/tests/api/test_plans_router.py
@@ -111,7 +111,7 @@ async def test_list_plans_returns_rows(monkeypatch: pytest.MonkeyPatch) -> None:
     ]
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     bind_calls: list[tuple[Any, str]] = []
 
@@ -158,7 +158,7 @@ async def test_list_plans_search_by_number_builds_like(monkeypatch: pytest.Monke
     rows: list[dict[str, Any]] = []
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     async def _fake_bind(*_: Any) -> None:
         return None
@@ -199,7 +199,7 @@ async def test_list_plans_search_by_name_builds_wildcard(monkeypatch: pytest.Mon
     rows: list[dict[str, Any]] = []
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     async def _fake_bind(*_: Any) -> None:
         return None
@@ -252,7 +252,7 @@ async def test_get_plans_search_by_number_returns_success(
     ]
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     async def _fake_bind(*_: Any) -> None:
         return None
@@ -308,7 +308,7 @@ async def test_get_plans_search_by_number_prefix_returns_success(
     ]
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     async def _fake_bind(*_: Any) -> None:
         return None
@@ -351,7 +351,7 @@ async def test_list_plans_requires_credentials(monkeypatch: pytest.MonkeyPatch) 
     def _unexpected_manager() -> _DummyManager:
         raise AssertionError("Connection should not be requested when credentials are missing")
 
-    monkeypatch.setattr(plans, "_get_connection_manager", _unexpected_manager)
+    monkeypatch.setattr(plans, "get_connection_manager", _unexpected_manager)
 
     async def _unexpected_bind(*_: Any) -> None:
         raise AssertionError("bind_session should not be called when credentials are missing")
@@ -381,7 +381,7 @@ async def test_list_plans_accepts_header_override(monkeypatch: pytest.MonkeyPatc
     rows: list[dict[str, Any]] = []
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     bind_calls: list[tuple[Any, str]] = []
 
@@ -423,7 +423,7 @@ async def test_list_plans_returns_unauthorized_when_binding_fails(
     rows: list[dict[str, Any]] = []
 
     manager = _DummyManager(rows)
-    monkeypatch.setattr(plans, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(plans, "get_connection_manager", lambda: manager)
 
     async def _raise_permission(*_: Any) -> None:
         raise PermissionError("Access denied")

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -34,7 +34,7 @@ def _setup_auth(monkeypatch, side_effect=None):
     manager = _ConnectionManager(connection)
     bind_mock = AsyncMock(side_effect=side_effect)
 
-    monkeypatch.setattr(auth_router, "_get_connection_manager", lambda: manager)
+    monkeypatch.setattr(auth_router, "get_connection_manager", lambda: manager)
     monkeypatch.setattr(auth_router, "bind_session", bind_mock)
 
     return connection, bind_mock


### PR DESCRIPTION
## Summary
- add an API dependencies module exposing a shared connection manager helper
- update auth and plans routers to consume the shared helper instead of local copies
- adjust router tests to patch the new dependency function

## Testing
- pytest tests/api

------
https://chatgpt.com/codex/tasks/task_e_68dd058971848323b3c2cd0ddda24be6