### PR TITLE
Remove duplicate only_digits helper

### DIFF
--- a/shared/text.py
+++ b/shared/text.py
@@ -32,8 +32,3 @@ def normalize_document(value: Any, *, allow_empty: bool = False) -> str | None:
         return ""
 
     return None
-
-def only_digits(value: Any) -> str:
-    """Return the digits extracted from ``value`` as a contiguous string."""
-
-    return "".join(character for character in str(value or "") if character.isdigit())


### PR DESCRIPTION
## Summary
- remove the duplicated definition of `only_digits` in `shared/text.py`
- keep a single implementation shared by `normalize_document`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd07c73484832387a57cd34c41ae53