### PR TITLE
Fix broken __future__ import in API dependencies

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,7 +1,5 @@
 """Shared dependencies for the API layer."""
 
-from __future__ import annotations
-
 from contextlib import AbstractAsyncContextManager
 
 from psycopg import AsyncConnection


### PR DESCRIPTION
## Summary
- remove the __future__.annotations import from the API dependencies module to avoid runtime errors on older interpreters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd167cc46c832391949f7da11b0ea0