### PR TITLE
Fix psycopg async connection import path

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -2,7 +2,7 @@
 
 from contextlib import AbstractAsyncContextManager
 
-from psycopg import AsyncConnection
+from psycopg.connection import AsyncConnection
 
 from infra.db import get_connection
 

--- a/api/routers/plans.py
+++ b/api/routers/plans.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Query, Request, status
-from psycopg import AsyncConnection
+from psycopg.connection import AsyncConnection
 from psycopg.errors import InvalidAuthorizationSpecification
 from psycopg.rows import dict_row
 

--- a/infra/audit.py
+++ b/infra/audit.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Any, Iterator, Optional
 
-from psycopg import AsyncConnection, Connection
+from psycopg.connection import AsyncConnection, Connection
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
 

--- a/infra/db.py
+++ b/infra/db.py
@@ -4,7 +4,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Optional
 
-from psycopg import AsyncConnection
+from psycopg.connection import AsyncConnection
 from psycopg_pool import AsyncConnectionPool
 
 from .audit import bind_session_by_matricula_async


### PR DESCRIPTION
## Summary
- update API and infrastructure modules to import `AsyncConnection` from the psycopg connection module
- keep AsyncConnection type hints consistent across the codebase to avoid broken imports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd16ec04c48323b468d3c0e47da1a6