### PR TITLE
Fix AsyncContextManager import in API dependencies

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,13 +1,13 @@
 """Shared dependencies for the API layer."""
 
-from contextlib import AbstractAsyncContextManager
+from typing import AsyncContextManager
 
 from psycopg import AsyncConnection
 
 from infra.db import get_connection
 
 
-def get_connection_manager() -> AbstractAsyncContextManager[AsyncConnection]:
+def get_connection_manager() -> AsyncContextManager[AsyncConnection]:
     """Return the shared database connection context manager."""
 
     return get_connection()


### PR DESCRIPTION
## Summary
- replace the use of `contextlib.AbstractAsyncContextManager` with the standard `typing.AsyncContextManager`
- ensure the database connection dependency uses an available type across Python versions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd1706bcc8832380f11d4b02c5f39a