### PR TITLE
Fix import error in FastAPI app module

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 
 from fastapi import FastAPI


### PR DESCRIPTION
## Summary
- remove the `__future__.annotations` import that breaks execution on older Python runtimes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd170fd87083239386ada5bba8479c