### PR TITLE
Fix Response import path in FastAPI app

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -2,9 +2,8 @@ from pathlib import Path
 from typing import Any, MutableMapping
 
 from fastapi import FastAPI
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
-from starlette.responses import Response
 
 # Local alias replicating ``starlette.types.Scope`` to avoid depending on optional typing helpers at runtime.
 Scope = MutableMapping[str, Any]


### PR DESCRIPTION
## Summary
- import `Response` from FastAPI's responses module to avoid missing dependency errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd17dfe1cc8323b542352931c835d2