### PR TITLE
Remove future annotations import from API models

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional


### PR DESCRIPTION
## Summary
- remove the `from __future__ import annotations` directive from `api/models.py` to avoid runtime import errors in environments where the future module lacks the annotations attribute

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd17f1f37083239c538264eed83ed5