### PR TITLE
Fix pydantic model config import

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 from domain.pipeline import PipelineState, PipelineStatus
 
@@ -24,7 +24,7 @@ class PipelineStateResponse(BaseModel):
     finished_at: Optional[datetime] = None
     message: Optional[str] = None
 
-    model_config = ConfigDict(from_attributes=True)
+    model_config = {"from_attributes": True}
 
     @classmethod
     def from_state(cls, state: PipelineState) -> "PipelineStateResponse":


### PR DESCRIPTION
## Summary
- replace the usage of `ConfigDict` with a plain configuration mapping so the model imports on older pydantic builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd17fafbe08323b4e5297e418d3e7a