### PR TITLE
Handle Pydantic compatibility in API models

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -4,7 +4,11 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+import pydantic
+
+BaseModel = getattr(pydantic, "BaseModel")
+ConfigDict = getattr(pydantic, "ConfigDict", dict)
+_HAS_MODEL_VALIDATE = hasattr(BaseModel, "model_validate")
 
 from domain.pipeline import PipelineState, PipelineStatus
 
@@ -24,13 +28,19 @@ class PipelineStateResponse(BaseModel):
     finished_at: Optional[datetime] = None
     message: Optional[str] = None
 
-    model_config = ConfigDict(from_attributes=True)
+    if _HAS_MODEL_VALIDATE:
+        model_config = ConfigDict(from_attributes=True)
+    else:  # pragma: no cover - exercised when running with Pydantic v1
+        class Config:  # type: ignore[no-redef]
+            orm_mode = True
 
     @classmethod
     def from_state(cls, state: PipelineState) -> "PipelineStateResponse":
         """Build response model from a domain state object."""
 
-        return cls.model_validate(state)
+        if _HAS_MODEL_VALIDATE:
+            return cls.model_validate(state)
+        return cls.from_orm(state)  # type: ignore[return-value]
 
 
 class PlanSummaryResponse(BaseModel):


### PR DESCRIPTION
## Summary
- load BaseModel and ConfigDict using getattr so the API works with both Pydantic v1 and v2
- fall back to the legacy Config/`from_orm` path when `model_validate` is unavailable

## Testing
- pytest *(fails: missing optional dependencies psycopg and fastapi in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd18037454832387e417c06ea44d20