### PR TITLE
Normalize plan status labels for plans dashboard

### DIFF
--- a/tests/api/test_plans_router.py
+++ b/tests/api/test_plans_router.py
@@ -27,6 +27,31 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Passivel de Rescisao", "P. RESCISAO"),
+        ("Passível de Rescisão", "P. RESCISAO"),
+        ("Situacao especial", "SIT. ESPECIAL"),
+        ("Situação especial", "SIT. ESPECIAL"),
+        ("GRDE emitida", "GRDE Emitida"),
+        ("Liquidado", "LIQUIDADO"),
+        ("Rescindido", "RESCINDIDO"),
+        ("EM_DIA", "EM_DIA"),
+    ],
+)
+def test_row_to_plan_summary_formats_status(raw: str, expected: str) -> None:
+    summary = plans._row_to_plan_summary({"numero_plano": "42", "situacao": raw})
+
+    assert summary.status == expected
+
+
+def test_row_to_plan_summary_handles_missing_status() -> None:
+    summary = plans._row_to_plan_summary({"numero_plano": "42"})
+
+    assert summary.status is None
+
+
 class _DummyCursor:
     def __init__(self, rows: list[dict[str, Any]]) -> None:
         self._rows = rows


### PR DESCRIPTION
## Summary
- map raw plan status descriptions returned by the plans endpoint to the desired dashboard labels
- add tests covering the new status formatting and missing-status handling

## Testing
- pytest tests/api/test_plans_router.py

------
https://chatgpt.com/codex/tasks/task_e_68dd348f9ed48323a480b229c7b23175