### PR TITLE
Fix last update label capitalization

### DIFF
--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
     occurrences: '',
   };
   if (lastUpdateLabel) {
-    lastUpdateLabel.textContent = 'última atualização em —';
+    lastUpdateLabel.textContent = 'Última atualização em: —';
   }
   let currentPlansSearchTerm = '';
   let currentOccurrencesSearchTerm = '';
@@ -217,7 +217,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const timestamp = lastSuccessfulFinishedAt ?? null;
     const formatted = formatDateTimeLabel(timestamp);
-    lastUpdateLabel.textContent = `última atualização em ${formatted}`;
+    lastUpdateLabel.textContent = `Última atualização em: ${formatted}`;
   };
 
   const refreshPipelineMeta = async () => {


### PR DESCRIPTION
## Summary
- ensure the UI uses the capitalized "Última atualização em" label with a colon for both default and updated timestamps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd865b771483238d4e30d5eccbe72f