### PR TITLE
Keep pause controls aligned with start button

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -205,6 +205,14 @@ input:focus {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  align-items: flex-start;
+}
+
+.controls__start-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .controls__info {
@@ -214,8 +222,9 @@ input:focus {
 
 .pipeline-meta {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .pipeline-meta span {

--- a/ui/index.html
+++ b/ui/index.html
@@ -51,12 +51,14 @@
           <div class="controls" role="group" aria-label="Controles de execução">
             <div class="controls__group">
               <div class="controls__start">
-                <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
-                <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
-                <div id="pipeline-meta" class="pipeline-meta">
-                  <span id="lbl-last-update">Última atualização em: —</span>
-                  <span id="lbl-last-duration">Duração da última atualização: —</span>
+                <div class="controls__start-row">
+                  <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
+                  <div id="pipeline-meta" class="pipeline-meta">
+                    <span id="lbl-last-update">Última atualização em: —</span>
+                    <span id="lbl-last-duration">Duração da última atualização: —</span>
+                  </div>
                 </div>
+                <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
               </div>
               <button class="btn btn--ghost" id="btnPause" type="button" disabled>Pausar</button>
               <button class="btn btn--ghost" id="btnContinue" type="button" disabled>Continuar</button>


### PR DESCRIPTION
## Summary
- wrap the start button and pipeline metadata in a horizontal row to keep the info beside the start action
- ensure the pause and continue buttons remain adjacent to the start controls via new flex styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd88c0a45c8323adcab4b474a9e6a5