### PR TITLE
Place pipeline metadata below start button

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -205,6 +205,7 @@ input:focus {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  align-items: flex-start;
 }
 
 .controls__info {
@@ -214,8 +215,9 @@ input:focus {
 
 .pipeline-meta {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .pipeline-meta span {

--- a/ui/index.html
+++ b/ui/index.html
@@ -52,11 +52,11 @@
             <div class="controls__group">
               <div class="controls__start">
                 <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
-                <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
                 <div id="pipeline-meta" class="pipeline-meta">
                   <span id="lbl-last-update">Última atualização em: —</span>
                   <span id="lbl-last-duration">Duração da última atualização: —</span>
                 </div>
+                <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
               </div>
               <button class="btn btn--ghost" id="btnPause" type="button" disabled>Pausar</button>
               <button class="btn btn--ghost" id="btnContinue" type="button" disabled>Continuar</button>


### PR DESCRIPTION
## Summary
- move the pipeline metadata block below the Iniciar button while keeping the info items side by side
- remove the unused layout wrapper created in the previous iteration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd88c0a45c8323adcab4b474a9e6a5