### PR TITLE
Fix duplicated start control layout

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -51,10 +51,6 @@
           <div class="controls" role="group" aria-label="Controles de execução">
             <div class="controls__group">
               <div class="controls__start">
-                <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
-                <div id="pipeline-meta" class="pipeline-meta">
-                  <span id="lbl-last-update">Última atualização em: —</span>
-                  <span id="lbl-last-duration">Duração da última atualização: —</span>
                 <div class="controls__start-row">
                   <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
                   <div id="pipeline-meta" class="pipeline-meta">


### PR DESCRIPTION
## Summary
- wrap the base panel start button and metadata in a single row container to remove duplicate markup

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd8da65420832386fcc78978d5033e