### PR TITLE
Rearrange start controls layout

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -199,6 +199,7 @@ input:focus {
   display: flex;
   gap: 12px;
   align-items: flex-start;
+  flex-wrap: wrap;
 }
 
 .controls__start {
@@ -208,13 +209,6 @@ input:focus {
   align-items: flex-start;
 }
 
-.controls__start-row {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 12px;
-}
-
 .controls__info {
   font-size: 12px;
   color: var(--muted);
@@ -222,14 +216,20 @@ input:focus {
 
 .pipeline-meta {
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 12px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
 }
 
 .pipeline-meta span {
   color: var(--muted);
   font-size: 12px;
+}
+
+.controls__actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
 }
 
 .btn {

--- a/ui/index.html
+++ b/ui/index.html
@@ -48,21 +48,21 @@
         </div>
 
         <div id="panel-base" class="card__panel" role="tabpanel" aria-labelledby="tab-base">
-          <div class="controls" role="group" aria-label="Controles de execução">
-            <div class="controls__group">
-              <div class="controls__start">
-                <div class="controls__start-row">
+            <div class="controls" role="group" aria-label="Controles de execução">
+              <div class="controls__group">
+                <div class="controls__start">
                   <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
                   <div id="pipeline-meta" class="pipeline-meta">
                     <span id="lbl-last-update">Última atualização em: —</span>
                     <span id="lbl-last-duration">Duração da última atualização: —</span>
                   </div>
+                  <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
                 </div>
-                <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
+                <div class="controls__actions">
+                  <button class="btn btn--ghost" id="btnPause" type="button" disabled>Pausar</button>
+                  <button class="btn btn--ghost" id="btnContinue" type="button" disabled>Continuar</button>
+                </div>
               </div>
-              <button class="btn btn--ghost" id="btnPause" type="button" disabled>Pausar</button>
-              <button class="btn btn--ghost" id="btnContinue" type="button" disabled>Continuar</button>
-            </div>
             <div class="status" id="statusText">Estado: Ocioso</div>
           </div>
 


### PR DESCRIPTION
## Summary
- move the pipeline metadata so that it appears below the Iniciar button
- group the execution buttons so Pausar and Continuar align with the start control
- adjust styling to stack metadata text and keep the button row aligned on wrap

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd8fcbd26c83238940171486f0bbfe