### PR TITLE
Align pause controls with start buttons

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -209,6 +209,13 @@ input:focus {
   align-items: flex-start;
 }
 
+.controls__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
 .controls__info {
   font-size: 12px;
   color: var(--muted);
@@ -224,12 +231,6 @@ input:focus {
 .pipeline-meta span {
   color: var(--muted);
   font-size: 12px;
-}
-
-.controls__actions {
-  display: flex;
-  gap: 12px;
-  align-items: center;
 }
 
 .btn {

--- a/ui/index.html
+++ b/ui/index.html
@@ -48,21 +48,21 @@
         </div>
 
         <div id="panel-base" class="card__panel" role="tabpanel" aria-labelledby="tab-base">
-            <div class="controls" role="group" aria-label="Controles de execução">
-              <div class="controls__group">
-                <div class="controls__start">
+          <div class="controls" role="group" aria-label="Controles de execução">
+            <div class="controls__group">
+              <div class="controls__start">
+                <div class="controls__buttons">
                   <button class="btn btn--primary" id="btnStart" type="button">Iniciar</button>
-                  <div id="pipeline-meta" class="pipeline-meta">
-                    <span id="lbl-last-update">Última atualização em: —</span>
-                    <span id="lbl-last-duration">Duração da última atualização: —</span>
-                  </div>
-                  <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
-                </div>
-                <div class="controls__actions">
                   <button class="btn btn--ghost" id="btnPause" type="button" disabled>Pausar</button>
                   <button class="btn btn--ghost" id="btnContinue" type="button" disabled>Continuar</button>
                 </div>
+                <div id="pipeline-meta" class="pipeline-meta">
+                  <span id="lbl-last-update">Última atualização em: —</span>
+                  <span id="lbl-last-duration">Duração da última atualização: —</span>
+                </div>
+                <p class="controls__info" id="lastUpdateInfo" aria-live="polite"></p>
               </div>
+            </div>
             <div class="status" id="statusText">Estado: Ocioso</div>
           </div>
 
@@ -307,14 +307,14 @@
           <div class="controls" role="group" aria-label="Controles de execução do Tratamento">
             <div class="controls__group">
               <div class="controls__start">
-                <div class="controls__start-row">
+                <div class="controls__buttons">
                   <button class="btn btn--ghost" id="btnMigratePlans" type="button">Migrar planos</button>
                   <button class="btn btn--primary" id="btnStartTreatment" type="button">Iniciar</button>
+                  <button class="btn btn--ghost" id="btnPauseTreatment" type="button" disabled>Pausar</button>
+                  <button class="btn btn--ghost" id="btnContinueTreatment" type="button" disabled>Continuar</button>
                 </div>
                 <p class="controls__info" id="treatmentInfo" aria-live="polite">Tratamento ocioso</p>
               </div>
-              <button class="btn btn--ghost" id="btnPauseTreatment" type="button" disabled>Pausar</button>
-              <button class="btn btn--ghost" id="btnContinueTreatment" type="button" disabled>Continuar</button>
             </div>
             <div class="status" id="treatmentStatusText">Estado: Ocioso</div>
           </div>


### PR DESCRIPTION
## Summary
- group the start, pause, and continue controls on the Gestão da Base tab so they stay side by side
- apply the same horizontal layout to the tratamento buttons for consistent spacing
- add a shared button row style to keep action buttons aligned and wrapped when needed

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd91a9ef048323b6388a9e09f970f9