### PR TITLE
Display company name in running plan summary

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -332,6 +332,10 @@
                   <span class="kv__value" id="currentPlanDocument">—</span>
                 </div>
                 <div class="kv">
+                  <span class="kv__label">RAZÃO SOCIAL</span>
+                  <span class="kv__value" id="currentPlanCompanyName">—</span>
+                </div>
+                <div class="kv">
                   <span class="kv__label">SITUAÇÃO</span>
                   <span class="kv__value" id="currentPlanStatus">—</span>
                 </div>


### PR DESCRIPTION
## Summary
- show the Razão Social field alongside plan, document, status and stage in the running plan card
- hydrate the running plan display from pipeline state data so company names render when available

## Testing
- pytest *(fails: environment lacks database/auth test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaef3f29c8323a67ba4ff949bb814