### PR TITLE
Remove idle treatment label from migration controls

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -313,7 +313,6 @@
                   <button class="btn btn--ghost" id="btnPauseTreatment" type="button" disabled>Pausar</button>
                   <button class="btn btn--ghost" id="btnContinueTreatment" type="button" disabled>Continuar</button>
                 </div>
-                <p class="controls__info" id="treatmentInfo" aria-live="polite">Tratamento ocioso</p>
               </div>
             </div>
             <div class="status" id="treatmentStatusText">Estado: Ocioso</div>


### PR DESCRIPTION
## Summary
- remove the idle treatment info paragraph below the migrate plans button on the treatment tab

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddb49bc9b08323ab0cd8a79d0477c6