### PR TITLE
Adjust Gestão da Base KPI spacing

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -176,7 +176,7 @@ input:focus {
 .card__panel {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
 }
 
 .card__panel--hidden {
@@ -962,7 +962,7 @@ input:focus {
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
-  margin-top: 16px;
+  margin-top: 0;
 }
 
 .kpi-card {


### PR DESCRIPTION
## Summary
- reduce the vertical spacing between the start controls and KPI cards on the Gestão da Base page to bring the indicators closer to the Iniciar button

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ddd4df03dc83238059b35a6d3352e3