### PR TITLE
Reduce spacing around plans table controls

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -619,6 +619,12 @@ input:focus {
   font-weight: 600;
 }
 
+.table-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
 .table {
   border: 1px solid var(--border);
   border-radius: 10px;

--- a/ui/index.html
+++ b/ui/index.html
@@ -92,72 +92,73 @@
             </div>
           </div>
 
-          <div class="section-title section-title--tables">
-            <div
-              class="section-switch-group"
-              role="tablist"
-              aria-label="Listas de planos"
-            >
-              <button
-                class="section-switch section-switch--active"
-                id="plansTableTab"
-                type="button"
-                role="tab"
-                aria-selected="true"
-                aria-controls="plansTablePanel"
-                data-table-target="plans"
-                tabindex="0"
+          <div class="table-section">
+            <div class="section-title section-title--tables">
+              <div
+                class="section-switch-group"
+                role="tablist"
+                aria-label="Listas de planos"
               >
-                TABELA DE PLANOS
-              </button>
-              <button
-                class="section-switch"
-                id="occurrencesTableTab"
-                type="button"
-                role="tab"
-                aria-selected="false"
-                aria-controls="occurrencesTablePanel"
-                data-table-target="occurrences"
-                tabindex="-1"
+                <button
+                  class="section-switch section-switch--active"
+                  id="plansTableTab"
+                  type="button"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="plansTablePanel"
+                  data-table-target="plans"
+                  tabindex="0"
+                >
+                  TABELA DE PLANOS
+                </button>
+                <button
+                  class="section-switch"
+                  id="occurrencesTableTab"
+                  type="button"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="occurrencesTablePanel"
+                  data-table-target="occurrences"
+                  tabindex="-1"
+                >
+                  OCORRÊNCIAS
+                  <span class="section-switch__count" id="occurrencesCount">(0)</span>
+                </button>
+              </div>
+
+              <form
+                class="table-search"
+                id="tableSearchForm"
+                role="search"
+                autocomplete="off"
               >
-                OCORRÊNCIAS
-                <span class="section-switch__count" id="occurrencesCount">(0)</span>
-              </button>
+                <label class="sr-only" for="tableSearchInput"
+                  >Digite o número do plano, CNPJ/CEI ou razão social…</label
+                >
+                <input
+                  class="table-search__input"
+                  type="search"
+                  id="tableSearchInput"
+                  name="q"
+                  placeholder="Digite o número do plano, CNPJ/CEI ou razão social…"
+                  aria-label="Digite o número do plano, CNPJ/CEI ou razão social…"
+                />
+                <button class="table-search__button" type="submit" aria-label="Buscar">
+                  <i data-feather="search" aria-hidden="true"></i>
+                </button>
+              </form>
             </div>
 
-            <form
-              class="table-search"
-              id="tableSearchForm"
-              role="search"
-              autocomplete="off"
+            <div
+              class="table-panel"
+              id="plansTablePanel"
+              role="tabpanel"
+              aria-labelledby="plansTableTab"
+              data-table-panel="plans"
             >
-              <label class="sr-only" for="tableSearchInput"
-                >Digite o número do plano, CNPJ/CEI ou razão social…</label
-              >
-              <input
-                class="table-search__input"
-                type="search"
-                id="tableSearchInput"
-                name="q"
-                placeholder="Digite o número do plano, CNPJ/CEI ou razão social…"
-                aria-label="Digite o número do plano, CNPJ/CEI ou razão social…"
-              />
-              <button class="table-search__button" type="submit" aria-label="Buscar">
-                <i data-feather="search" aria-hidden="true"></i>
-              </button>
-            </form>
-          </div>
-
-          <div
-            class="table-panel"
-            id="plansTablePanel"
-            role="tabpanel"
-            aria-labelledby="plansTableTab"
-            data-table-panel="plans"
-          >
-            <div class="table-active-filters" id="plansFiltersChips" hidden></div>
-            <div class="table">
-              <table class="data-table" aria-label="Tabela de planos">
+              <div class="table-active-filters" id="plansFiltersChips" hidden></div>
+              <div class="table">
+                <table class="data-table" aria-label="Tabela de planos">
                 <thead class="table__head">
                   <tr>
                     <th scope="col">PLANO</th>
@@ -549,8 +550,9 @@
               </div>
             </div>
           </div>
+        </div>
 
-          <div class="accordion accordion--compact">
+        <div class="accordion accordion--compact">
             <div class="accordion__header">
               <button
                 class="accordion__toggle"


### PR DESCRIPTION
## Summary
- wrap the plans table header controls and data panels in a dedicated container to keep them visually grouped
- add layout styling for the new container to tighten the vertical spacing between the title, search bar, and table

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ddd68577cc83238eb86ed67629af0f