### PR TITLE
Add pytest pre-commit hook and document setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pytest
+        name: Run pytest
+        entry: bash -c 'pytest'
+        language: system
+        pass_filenames: false
+        stages: [commit]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,14 @@
 - `scripts/`: auxiliary CLIs; document in `docs/` when added.
 
 ## Build, Test, and Development Commands
+- Install git hooks so tests run automatically before each commit: `pre-commit install`
 - Start API: `uvicorn api.app:create_app --reload`
 - Run tests: `pytest`
 - Lint: `ruff check .` | Format: `ruff format .`
 - Type check: `mypy .`
 Run all from repo root.
+
+Git hooks rely on `pre-commit` being available in your environment. Install development dependencies with `pip install -e .[dev]` or an equivalent command in your toolchain before enabling the hook.
 
 ## Coding Style & Naming Conventions
 - PEP 8, 4‑space indentation, descriptive English identifiers (UI strings may be Portuguese).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ test = [
     "pytest>=8.0",
     "httpx>=0.27,<1.0",
 ]
+dev = [
+    "pre-commit>=3.7",
+    "pytest>=8.0",
+    "httpx>=0.27,<1.0",
+]
 
 [tool.setuptools]
 package-dir = {"" = "."}


### PR DESCRIPTION
## Summary
- add a local pre-commit hook that runs pytest before every commit so agents execute tests automatically
- document the hook workflow in AGENTS.md and point to the development dependency installation command
- expose a `dev` optional dependency set that bundles pre-commit and pytest for easier environment setup

## Testing
- pytest *(fails: existing tests report query iteration errors and repository assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd7fc6a148323aeff94718e3b763a