### PR TITLE
Align treatment KPI card to the right

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -940,8 +940,13 @@ input:focus {
 
 .running-plan {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr auto;
   gap: 16px;
+  align-items: start;
+}
+
+.running-plan__col:last-child {
+  justify-self: end;
 }
 
 .running-plan__col {


### PR DESCRIPTION
## Summary
- adjust the treatment running-plan layout to size the KPI column automatically and align it on the right edge of the card
- keep the KPI column anchored to the right by justifying the final column within the grid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddd8913f8c8323809da29366e0af95