### PR TITLE
Improve spacing between treatment KPI labels and values

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -1027,18 +1027,22 @@ input:focus {
 }
 
 .running-plan__col .kpi-row {
-  align-items: baseline;
-  gap: 16px;
+  align-items: center;
+  gap: 24px;
 }
 
 .running-plan__col .kpi-label {
   font-size: 12px;
   letter-spacing: 0.6px;
+  flex: 1;
 }
 
 .running-plan__col .kpi-value {
   font-size: 22px;
   line-height: 1.2;
+  flex-shrink: 0;
+  min-width: 3.5ch;
+  text-align: right;
 }
 
 .filters {


### PR DESCRIPTION
## Summary
- adjust the treatment KPI layout so labels stretch and keep a larger gap before the values
- prevent KPI totals from crowding the labels by reserving width and keeping the text right-aligned

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dddaa19acc8323b7e7ceb36654b206