### PR TITLE
Adjust footer spacing beneath main card

### DIFF
--- a/ui/css/styles.css
+++ b/ui/css/styles.css
@@ -120,7 +120,7 @@ input:focus {
   flex: 1;
   display: flex;
   justify-content: center;
-  padding: 40px 24px 64px;
+  padding: 40px 24px 48px;
 }
 
 .card {
@@ -1185,7 +1185,7 @@ input:focus {
 
 .footer {
   text-align: center;
-  padding: 32px 16px 48px;
+  padding: 24px 16px 40px;
   font-size: 13px;
   color: var(--muted);
   line-height: 1.6;


### PR DESCRIPTION
## Summary
- reduce the main layout's bottom padding to minimize the gap below the principal card
- decrease the footer's top and bottom padding so it sits closer to the card while keeping balanced spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dddc5689648323a4dd52a92ace9c04