### PR TITLE
Disable blocking plans in treatment

### DIFF
--- a/ui/js/app/context.js
+++ b/ui/js/app/context.js
@@ -51,6 +51,7 @@ export function createAppContext() {
   context.plansActionsMenu = document.getElementById('plansActionsMenu');
   context.plansSelectAllAction = context.plansActionsMenu?.querySelector('[data-action="select-all"]') ?? null;
   context.plansSelectAllLabel = context.plansSelectAllAction?.querySelector('span') ?? null;
+  context.plansLockAction = context.plansActionsMenu?.querySelector('[data-action="lock"]') ?? null;
   context.plansActionsSeparator = context.plansActionsMenu?.querySelector('[data-role="separator"]') ?? null;
   context.plansFiltersChipsContainer = document.getElementById('plansFiltersChips');
   context.occFiltersChipsContainer = document.getElementById('occFiltersChips');
@@ -114,6 +115,7 @@ export function createAppContext() {
     dtRange: null,
   };
   context.plansSelection = new Set();
+  context.planMetadataById = new Map();
   context.FILTER_LABELS = {
     situacao: {
       EM_DIA: 'EM DIA',

--- a/ui/js/app/plans.js
+++ b/ui/js/app/plans.js
@@ -11,16 +11,82 @@ export function registerPlansModule(context) {
     plansSelectAllLabel,
     plansActionsSeparator,
     filtersState,
+    planMetadataById,
     plansPagerPrevBtn,
     plansPagerNextBtn,
     plansPagerLabel,
     plansPagerRange,
     PLANS_ENDPOINT,
     DEFAULT_PLAN_PAGE_SIZE,
+    plansLockAction,
   } = context;
 
   const plansPager = context.plansPager;
   const planCheckboxSelector = "input[type='checkbox'][data-plan-checkbox]";
+
+  const getPlanMetadata = (planId) => {
+    if (!planId || typeof planId !== 'string') {
+      return null;
+    }
+    if (!(planMetadataById instanceof Map)) {
+      return null;
+    }
+    const metadata = planMetadataById.get(planId) ?? null;
+    if (!metadata || typeof metadata !== 'object') {
+      return null;
+    }
+    return metadata;
+  };
+
+  const isPlanInTreatment = (planId) => {
+    const metadata = getPlanMetadata(planId);
+    if (!metadata) {
+      return false;
+    }
+    if (metadata.isQueued) {
+      return true;
+    }
+    const status = typeof metadata.status === 'string' ? metadata.status.trim().toLowerCase() : '';
+    return status.includes('em tratamento');
+  };
+
+  const updateLockActionState = (hasSelection) => {
+    if (!(plansLockAction instanceof HTMLElement)) {
+      return;
+    }
+    const selectedPlanIds = new Set(plansSelection);
+    if (plansTableBody) {
+      const checked = plansTableBody.querySelectorAll(
+        `${planCheckboxSelector}:checked:not(:disabled)`,
+      );
+      checked.forEach((checkbox) => {
+        if (!(checkbox instanceof HTMLInputElement)) {
+          return;
+        }
+        const planId = checkbox.dataset.planId ?? '';
+        if (planId) {
+          selectedPlanIds.add(planId);
+        }
+      });
+    }
+
+    let disabledDueToTreatment = false;
+    for (const planId of selectedPlanIds) {
+      if (isPlanInTreatment(planId)) {
+        disabledDueToTreatment = true;
+        break;
+      }
+    }
+
+    const shouldDisable = disabledDueToTreatment || !hasSelection;
+    plansLockAction.disabled = shouldDisable;
+    plansLockAction.setAttribute('aria-disabled', String(shouldDisable));
+    if (disabledDueToTreatment) {
+      plansLockAction.title = 'Plano em tratamento não pode ser bloqueado';
+    } else {
+      plansLockAction.removeAttribute('title');
+    }
+  };
 
   const getFirstVisiblePlansAction = () => {
     if (!plansActionsMenu) {
@@ -73,6 +139,8 @@ export function registerPlansModule(context) {
         plansActionsSeparator.setAttribute('hidden', 'hidden');
       }
     }
+
+    updateLockActionState(hasSelection);
 
     if (plansSelectAllAction instanceof HTMLElement) {
       const isDisabled = totalEnabledCheckboxes === 0;
@@ -217,6 +285,9 @@ export function registerPlansModule(context) {
       return;
     }
     plansSelection.clear();
+    if (planMetadataById instanceof Map) {
+      planMetadataById.clear();
+    }
     updatePlansActionsMenuState();
     closePlansActionsMenu();
     plansTableBody.innerHTML = '';
@@ -286,6 +357,9 @@ export function registerPlansModule(context) {
     plansTableBody.innerHTML = '';
     plansSelection.clear();
     closePlansActionsMenu();
+    if (planMetadataById instanceof Map) {
+      planMetadataById.clear();
+    }
     const plans = Array.isArray(items) ? items : [];
     if (!plans.length) {
       if (state.currentPlansSearchTerm) {
@@ -315,6 +389,12 @@ export function registerPlansModule(context) {
 
       const queueInfo = item?.treatment_queue ?? null;
       const isQueued = Boolean(queueInfo?.enqueued);
+      if (planId && planMetadataById instanceof Map) {
+        planMetadataById.set(planId, {
+          status: typeof item?.status === 'string' ? item.status : '',
+          isQueued,
+        });
+      }
       const planCell = document.createElement('td');
       planCell.className = 'table__cell';
       planCell.textContent = item?.number ?? '';


### PR DESCRIPTION
## Summary
- capture plan queue and status metadata when rendering the plans table
- disable the "Bloquear" bulk action whenever the selection contains planos em tratamento
- reset cached plan metadata when the table is cleared or re-rendered

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3419ea7308323a566ba74fcc22927